### PR TITLE
Modify Z3 dependency of analysis project to tests only

### DIFF
--- a/hu.bme.mit.theta.analysis/build.gradle
+++ b/hu.bme.mit.theta.analysis/build.gradle
@@ -2,8 +2,8 @@ dependencies {
   compile project(':hu.bme.mit.theta.common')
   compile project(':hu.bme.mit.theta.core')
   compile project(':hu.bme.mit.theta.solver')
-  compile project(':hu.bme.mit.theta.solver.z3')
   compile group: 'com.google.guava', name: 'guava', version: guavaVersion
+  testCompile project(':hu.bme.mit.theta.solver.z3')
   testCompile group: 'junit', name: 'junit', version: junitVersion
   testCompile group: 'org.mockito', name: 'mockito-core', version: mockitoVersion
 }

--- a/hu.bme.mit.theta.formalism.cfa/build.gradle
+++ b/hu.bme.mit.theta.formalism.cfa/build.gradle
@@ -5,6 +5,7 @@ dependencies {
   compile project(':hu.bme.mit.theta.common')
   compile project(':hu.bme.mit.theta.core')
   compile project(':hu.bme.mit.theta.analysis')
+  compile project(':hu.bme.mit.theta.solver.z3')
   antlr group: 'org.antlr', name: 'antlr4', version: antlrVersion
   compile group: 'com.beust', name: 'jcommander', version: jcommanderVersion
   compile group: 'com.google.guava', name: 'guava', version: guavaVersion

--- a/hu.bme.mit.theta.formalism.sts/build.gradle
+++ b/hu.bme.mit.theta.formalism.sts/build.gradle
@@ -5,6 +5,7 @@ dependencies {
   compile project(':hu.bme.mit.theta.common')
   compile project(':hu.bme.mit.theta.core')
   compile project(':hu.bme.mit.theta.analysis')
+  compile project(':hu.bme.mit.theta.solver.z3')
   antlr group: 'org.antlr', name: 'antlr4', version: antlrVersion
   compile group: 'com.beust', name: 'jcommander', version: jcommanderVersion
   compile group: 'com.google.guava', name: 'guava', version: guavaVersion


### PR DESCRIPTION
The analysis project depends on Z3 only due to the tests, so I modified the dependency to be `testCompile`.