### PR TITLE
Make error loc of CFA optional, add targetloc argument to CLI tool

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ buildscript {
 
 allprojects {
     group = "hu.bme.mit.inf.theta"
-    version = "2.6.1"
+    version = "2.7.0"
 
     apply(from = rootDir.resolve("gradle/shared-with-buildSrc/mirrors.gradle.kts"))
 }

--- a/subprojects/cfa-analysis/src/main/java/hu/bme/mit/theta/cfa/analysis/DistToErrComparator.java
+++ b/subprojects/cfa-analysis/src/main/java/hu/bme/mit/theta/cfa/analysis/DistToErrComparator.java
@@ -41,13 +41,15 @@ public class DistToErrComparator implements ArgNodeComparator {
 	private final int errorWeight;
 	private final int depthWeight;
 	private final CFA cfa;
+	private final Loc errLoc;
 
-	public DistToErrComparator(final CFA cfa) {
-		this(cfa, 1, 0);
+	public DistToErrComparator(final CFA cfa, final Loc errLoc) {
+		this(cfa, errLoc, 1, 0);
 	}
 
-	public DistToErrComparator(final CFA cfa, final int errorWeight, final int depthWeight) {
+	public DistToErrComparator(final CFA cfa, final Loc errLoc, final int errorWeight, final int depthWeight) {
 		this.cfa = cfa;
+		this.errLoc = errLoc;
 		this.errorWeight = errorWeight;
 		this.depthWeight = depthWeight;
 		distancesToError = null;
@@ -74,16 +76,16 @@ public class DistToErrComparator implements ArgNodeComparator {
 
 	private int getDistanceToError(final Loc loc) {
 		if (distancesToError == null) {
-			distancesToError = calculateDistancesToError(cfa);
+			distancesToError = calculateDistancesToError(cfa, errLoc);
 		}
 		return distancesToError.getOrDefault(loc, Integer.MAX_VALUE);
 	}
 
-	static Map<Loc, Integer> calculateDistancesToError(final CFA cfa) {
+	static Map<Loc, Integer> calculateDistancesToError(final CFA cfa, final Loc errLoc) {
 		List<Loc> queue = new LinkedList<>();
 		final Map<Loc, Integer> distancesToError = new HashMap<>();
-		queue.add(cfa.getErrorLoc());
-		distancesToError.put(cfa.getErrorLoc(), 0);
+		queue.add(errLoc);
+		distancesToError.put(errLoc, 0);
 		int distance = 1;
 
 		while (!queue.isEmpty()) {

--- a/subprojects/cfa-analysis/src/main/java/hu/bme/mit/theta/cfa/analysis/config/CfaConfigBuilder.java
+++ b/subprojects/cfa-analysis/src/main/java/hu/bme/mit/theta/cfa/analysis/config/CfaConfigBuilder.java
@@ -147,19 +147,19 @@ public class CfaConfigBuilder {
 	public enum Encoding {
 		SBE {
 			@Override
-			public CfaLts getLts(CFA.Loc targetLoc) {
+			public CfaLts getLts(CFA.Loc errorLoc) {
 				return new CfaCachedLts(CfaSbeLts.getInstance());
 			}
 		},
 
 		LBE {
 			@Override
-			public CfaLts getLts(CFA.Loc targetLoc) {
-				return new CfaCachedLts(CfaLbeLts.of(targetLoc));
+			public CfaLts getLts(CFA.Loc errorLoc) {
+				return new CfaCachedLts(CfaLbeLts.of(errorLoc));
 			}
 		};
 
-		public abstract CfaLts getLts(CFA.Loc targetLoc);
+		public abstract CfaLts getLts(CFA.Loc errorLoc);
 	}
 
 	public enum InitPrec {

--- a/subprojects/cfa-analysis/src/main/java/hu/bme/mit/theta/cfa/analysis/config/CfaConfigBuilder.java
+++ b/subprojects/cfa-analysis/src/main/java/hu/bme/mit/theta/cfa/analysis/config/CfaConfigBuilder.java
@@ -147,19 +147,19 @@ public class CfaConfigBuilder {
 	public enum Encoding {
 		SBE {
 			@Override
-			public CfaLts getLts() {
+			public CfaLts getLts(CFA.Loc targetLoc) {
 				return new CfaCachedLts(CfaSbeLts.getInstance());
 			}
 		},
 
 		LBE {
 			@Override
-			public CfaLts getLts() {
-				return new CfaCachedLts(CfaLbeLts.getInstance());
+			public CfaLts getLts(CFA.Loc targetLoc) {
+				return new CfaCachedLts(new CfaLbeLts(targetLoc));
 			}
 		};
 
-		public abstract CfaLts getLts();
+		public abstract CfaLts getLts(CFA.Loc targetLoc);
 	}
 
 	public enum InitPrec {
@@ -226,7 +226,7 @@ public class CfaConfigBuilder {
 
 	public CfaConfig<? extends State, ? extends Action, ? extends Prec> build(final CFA cfa, final CFA.Loc errLoc) {
 		final ItpSolver solver = solverFactory.createItpSolver();
-		final CfaLts lts = encoding.getLts();
+		final CfaLts lts = encoding.getLts(errLoc);
 
 		if (domain == Domain.EXPL) {
 			final Analysis<CfaState<ExplState>, CfaAction, CfaPrec<ExplPrec>> analysis = CfaAnalysis

--- a/subprojects/cfa-analysis/src/main/java/hu/bme/mit/theta/cfa/analysis/config/CfaConfigBuilder.java
+++ b/subprojects/cfa-analysis/src/main/java/hu/bme/mit/theta/cfa/analysis/config/CfaConfigBuilder.java
@@ -74,26 +74,26 @@ public class CfaConfigBuilder {
 	public enum Search {
 		BFS {
 			@Override
-			public ArgNodeComparator getComp(final CFA cfa) {
+			public ArgNodeComparator getComp(final CFA cfa, final CFA.Loc errLoc) {
 				return ArgNodeComparators.combine(ArgNodeComparators.targetFirst(), ArgNodeComparators.bfs());
 			}
 		},
 
 		DFS {
 			@Override
-			public ArgNodeComparator getComp(final CFA cfa) {
+			public ArgNodeComparator getComp(final CFA cfa, final CFA.Loc errLoc) {
 				return ArgNodeComparators.combine(ArgNodeComparators.targetFirst(), ArgNodeComparators.dfs());
 			}
 		},
 
 		ERR {
 			@Override
-			public ArgNodeComparator getComp(final CFA cfa) {
-				return new DistToErrComparator(cfa);
+			public ArgNodeComparator getComp(final CFA cfa, final CFA.Loc errLoc) {
+				return new DistToErrComparator(cfa, errLoc);
 			}
 		};
 
-		public abstract ArgNodeComparator getComp(CFA cfa);
+		public abstract ArgNodeComparator getComp(CFA cfa, CFA.Loc errLoc);
 
 	}
 
@@ -224,7 +224,7 @@ public class CfaConfigBuilder {
 		return this;
 	}
 
-	public CfaConfig<? extends State, ? extends Action, ? extends Prec> build(final CFA cfa) {
+	public CfaConfig<? extends State, ? extends Action, ? extends Prec> build(final CFA cfa, final CFA.Loc errLoc) {
 		final ItpSolver solver = solverFactory.createItpSolver();
 		final CfaLts lts = encoding.getLts();
 
@@ -232,10 +232,10 @@ public class CfaConfigBuilder {
 			final Analysis<CfaState<ExplState>, CfaAction, CfaPrec<ExplPrec>> analysis = CfaAnalysis
 					.create(cfa.getInitLoc(), ExplStmtAnalysis.create(solver, True(), maxEnum));
 			final ArgBuilder<CfaState<ExplState>, CfaAction, CfaPrec<ExplPrec>> argBuilder = ArgBuilder.create(lts,
-					analysis, s -> s.getLoc().equals(cfa.getErrorLoc()), true);
+					analysis, s -> s.getLoc().equals(errLoc), true);
 			final Abstractor<CfaState<ExplState>, CfaAction, CfaPrec<ExplPrec>> abstractor = BasicAbstractor
 					.builder(argBuilder).projection(CfaState::getLoc)
-					.waitlist(PriorityWaitlist.create(search.getComp(cfa)))
+					.waitlist(PriorityWaitlist.create(search.getComp(cfa, errLoc)))
 					.stopCriterion(refinement == Refinement.MULTI_SEQ ? StopCriterions.fullExploration()
 							: StopCriterions.firstCex()).logger(logger).build();
 
@@ -372,10 +372,10 @@ public class CfaConfigBuilder {
 			final Analysis<CfaState<PredState>, CfaAction, CfaPrec<PredPrec>> analysis = CfaAnalysis
 					.create(cfa.getInitLoc(), PredAnalysis.create(solver, predAbstractor, True()));
 			final ArgBuilder<CfaState<PredState>, CfaAction, CfaPrec<PredPrec>> argBuilder = ArgBuilder.create(lts,
-					analysis, s -> s.getLoc().equals(cfa.getErrorLoc()), true);
+					analysis, s -> s.getLoc().equals(errLoc), true);
 			final Abstractor<CfaState<PredState>, CfaAction, CfaPrec<PredPrec>> abstractor = BasicAbstractor
 					.builder(argBuilder).projection(CfaState::getLoc)
-					.waitlist(PriorityWaitlist.create(search.getComp(cfa)))
+					.waitlist(PriorityWaitlist.create(search.getComp(cfa, errLoc)))
 					.stopCriterion(refinement == Refinement.MULTI_SEQ ? StopCriterions.fullExploration()
 							: StopCriterions.firstCex()).logger(logger).build();
 

--- a/subprojects/cfa-analysis/src/main/java/hu/bme/mit/theta/cfa/analysis/config/CfaConfigBuilder.java
+++ b/subprojects/cfa-analysis/src/main/java/hu/bme/mit/theta/cfa/analysis/config/CfaConfigBuilder.java
@@ -155,7 +155,7 @@ public class CfaConfigBuilder {
 		LBE {
 			@Override
 			public CfaLts getLts(CFA.Loc targetLoc) {
-				return new CfaCachedLts(new CfaLbeLts(targetLoc));
+				return new CfaCachedLts(CfaLbeLts.of(targetLoc));
 			}
 		};
 

--- a/subprojects/cfa-analysis/src/main/java/hu/bme/mit/theta/cfa/analysis/lts/CfaLbeLts.java
+++ b/subprojects/cfa-analysis/src/main/java/hu/bme/mit/theta/cfa/analysis/lts/CfaLbeLts.java
@@ -26,21 +26,18 @@ import hu.bme.mit.theta.cfa.analysis.CfaAction;
 import hu.bme.mit.theta.cfa.analysis.CfaState;
 import hu.bme.mit.theta.common.Utils;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 /**
  * Large block encoding (LBE) implementation for CFA LTS. It maps each path
  * (with no branching) into a single action.
  */
 public final class CfaLbeLts implements CfaLts {
 
-	private static final class LazyHolder {
-		private static final CfaLbeLts INSTANCE = new CfaLbeLts();
-	}
+	private Loc targetLoc;
 
-	private CfaLbeLts() {
-	}
-
-	public static CfaLbeLts getInstance() {
-		return LazyHolder.INSTANCE;
+	public CfaLbeLts(Loc targetLoc) {
+		this.targetLoc = checkNotNull(targetLoc, "Target location must be given for LBE encoder.");
 	}
 
 	@Override
@@ -52,7 +49,7 @@ public final class CfaLbeLts implements CfaLts {
 			final List<Edge> edges = new LinkedList<>();
 			edges.add(edge);
 			Loc running = edge.getTarget();
-			while (running.getInEdges().size() == 1 && running.getOutEdges().size() == 1) {
+			while (running.getInEdges().size() == 1 && running.getOutEdges().size() == 1 && !running.equals(targetLoc)) {
 				final Edge next = Utils.singleElementOf(running.getOutEdges());
 				edges.add(next);
 				running = next.getTarget();

--- a/subprojects/cfa-analysis/src/main/java/hu/bme/mit/theta/cfa/analysis/lts/CfaLbeLts.java
+++ b/subprojects/cfa-analysis/src/main/java/hu/bme/mit/theta/cfa/analysis/lts/CfaLbeLts.java
@@ -34,7 +34,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public final class CfaLbeLts implements CfaLts {
 
-	private Loc targetLoc;
+	private final Loc targetLoc;
 
 	public CfaLbeLts(Loc targetLoc) {
 		this.targetLoc = checkNotNull(targetLoc, "Target location must be given for LBE encoder.");

--- a/subprojects/cfa-analysis/src/main/java/hu/bme/mit/theta/cfa/analysis/lts/CfaLbeLts.java
+++ b/subprojects/cfa-analysis/src/main/java/hu/bme/mit/theta/cfa/analysis/lts/CfaLbeLts.java
@@ -36,8 +36,12 @@ public final class CfaLbeLts implements CfaLts {
 
 	private final Loc targetLoc;
 
-	public CfaLbeLts(Loc targetLoc) {
+	private CfaLbeLts(Loc targetLoc) {
 		this.targetLoc = checkNotNull(targetLoc, "Target location must be given for LBE encoder.");
+	}
+
+	public static CfaLbeLts of(Loc targetLoc) {
+		return new CfaLbeLts(targetLoc);
 	}
 
 	@Override

--- a/subprojects/cfa-analysis/src/main/java/hu/bme/mit/theta/cfa/analysis/utils/CfaVisualizer.java
+++ b/subprojects/cfa-analysis/src/main/java/hu/bme/mit/theta/cfa/analysis/utils/CfaVisualizer.java
@@ -82,14 +82,15 @@ public final class CfaVisualizer {
 		final String id = LOC_ID_PREFIX + ids.size();
 		ids.put(loc, id);
 		String label = loc.getName();
+		boolean isError = cfa.getErrorLoc().isPresent() && loc == cfa.getErrorLoc().get();
 		if (loc == cfa.getInitLoc()) {
 			label += " (init)";
-		} else if (loc == cfa.getFinalLoc()) {
+		} else if (cfa.getFinalLoc().isPresent() && loc == cfa.getFinalLoc().get()) {
 			label += " (end)";
-		} else if (loc == cfa.getErrorLoc()) {
+		} else if (isError) {
 			label += " (error)";
 		}
-		final int peripheries = loc == cfa.getErrorLoc() ? 2 : 1;
+		final int peripheries = isError ? 2 : 1;
 		final NodeAttributes nAttrs = NodeAttributes.builder().label(label).fillColor(FILL_COLOR).lineColor(LINE_COLOR)
 				.lineStyle(LOC_LINE_STYLE).peripheries(peripheries).build();
 		graph.addNode(id, nAttrs);

--- a/subprojects/cfa-analysis/src/test/java/hu/bme/mit/theta/cfa/analysis/CfaTest.java
+++ b/subprojects/cfa-analysis/src/test/java/hu/bme/mit/theta/cfa/analysis/CfaTest.java
@@ -125,7 +125,7 @@ public class CfaTest {
 	public void test() throws IOException {
 		CFA cfa = CfaDslManager.createCfa(new FileInputStream(filePath));
 		CfaConfig<? extends State, ? extends Action, ? extends Prec> config
-				= new CfaConfigBuilder(domain, refinement, Z3SolverFactory.getInstance()).build(cfa);
+				= new CfaConfigBuilder(domain, refinement, Z3SolverFactory.getInstance()).build(cfa, cfa.getErrorLoc().get());
 		SafetyResult<? extends State, ? extends Action> result = config.check();
 		Assert.assertEquals(isSafe, result.isSafe());
 		if (result.isUnsafe()) {

--- a/subprojects/cfa-analysis/src/test/java/hu/bme/mit/theta/cfa/analysis/DistanceToErrorLocComparatorTest.java
+++ b/subprojects/cfa-analysis/src/test/java/hu/bme/mit/theta/cfa/analysis/DistanceToErrorLocComparatorTest.java
@@ -49,7 +49,7 @@ public class DistanceToErrorLocComparatorTest {
 		builder.createEdge(loc2, locFinal, stmt);
 
 		final CFA cfa = builder.build();
-		final Map<Loc, Integer> distancesToError = DistToErrComparator.calculateDistancesToError(cfa);
+		final Map<Loc, Integer> distancesToError = DistToErrComparator.calculateDistancesToError(cfa, cfa.getErrorLoc().get());
 
 		Assert.assertEquals(0, (int) distancesToError.get(locErr));
 		Assert.assertEquals(2, (int) distancesToError.get(loc0));

--- a/subprojects/cfa-analysis/src/test/java/hu/bme/mit/theta/cfa/analysis/EncodingTest.java
+++ b/subprojects/cfa-analysis/src/test/java/hu/bme/mit/theta/cfa/analysis/EncodingTest.java
@@ -76,7 +76,7 @@ public class EncodingTest {
 
 	@Test
 	public void testLbe1() {
-		CfaLbeLts lts = new CfaLbeLts(getLocByName("L7"));
+		CfaLbeLts lts = CfaLbeLts.of(getLocByName("L7"));
 		Assert.assertEquals(ImmutableSet.of("L1"), getNextLocs(lts, "L0"));
 		Assert.assertEquals(ImmutableSet.of("L4"), getNextLocs(lts, "L1"));
 		Assert.assertEquals(ImmutableSet.of("L4"), getNextLocs(lts, "L2"));
@@ -89,7 +89,7 @@ public class EncodingTest {
 
 	@Test
 	public void testLbe2() {
-		CfaLbeLts lts = new CfaLbeLts(getLocByName("L3"));
+		CfaLbeLts lts = CfaLbeLts.of(getLocByName("L3"));
 		Assert.assertEquals(ImmutableSet.of("L1"), getNextLocs(lts, "L0"));
 		Assert.assertEquals(ImmutableSet.of("L3", "L4"), getNextLocs(lts, "L1"));
 		Assert.assertEquals(ImmutableSet.of("L3"), getNextLocs(lts, "L2"));

--- a/subprojects/cfa-analysis/src/test/java/hu/bme/mit/theta/cfa/analysis/EncodingTest.java
+++ b/subprojects/cfa-analysis/src/test/java/hu/bme/mit/theta/cfa/analysis/EncodingTest.java
@@ -1,0 +1,102 @@
+package hu.bme.mit.theta.cfa.analysis;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import hu.bme.mit.theta.analysis.State;
+import hu.bme.mit.theta.analysis.expr.ExprState;
+import hu.bme.mit.theta.cfa.CFA;
+import hu.bme.mit.theta.cfa.analysis.lts.CfaLbeLts;
+import hu.bme.mit.theta.cfa.analysis.lts.CfaLts;
+import hu.bme.mit.theta.cfa.analysis.lts.CfaSbeLts;
+import hu.bme.mit.theta.cfa.dsl.CfaDslManager;
+import hu.bme.mit.theta.core.type.Expr;
+import hu.bme.mit.theta.core.type.booltype.BoolType;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class EncodingTest {
+
+	private CFA cfa;
+
+	private CFA.Loc getLocByName(String name) {
+		for (CFA.Loc loc : cfa.getLocs()) {
+			if (loc.getName().equals(name)) return loc;
+		}
+		throw new IllegalArgumentException("Location not found");
+	}
+
+	private Set<String> getNextLocs(CfaLts lts, String loc) {
+		Set<String> locs = new HashSet<>();
+		SS ss = new SS();
+		for (var act : lts.getEnabledActionsFor(CfaState.of(getLocByName(loc), ss))) {
+			locs.add(act.getTarget().getName());
+		}
+		return locs;
+	}
+
+	private class SS implements ExprState {
+		@Override
+		public boolean isBottom() {
+			return false;
+		}
+
+		@Override
+		public Expr<BoolType> toExpr() {
+			return null;
+		}
+	}
+
+	@Before
+	public void load() throws IOException {
+		try (var fis = new FileInputStream("src/test/resources/block-encoding.cfa")) {
+			cfa = CfaDslManager.createCfa(fis);
+		}
+	}
+
+	@Test
+	public void testSbe() {
+		CfaSbeLts lts = CfaSbeLts.getInstance();
+		Assert.assertEquals(ImmutableSet.of("L1"), getNextLocs(lts, "L0"));
+		Assert.assertEquals(ImmutableSet.of("L2", "L4"), getNextLocs(lts, "L1"));
+		Assert.assertEquals(ImmutableSet.of("L3"), getNextLocs(lts, "L2"));
+		Assert.assertEquals(ImmutableSet.of("L4"), getNextLocs(lts, "L3"));
+		Assert.assertEquals(ImmutableSet.of("L5"), getNextLocs(lts, "L4"));
+		Assert.assertEquals(ImmutableSet.of("L1", "L6"), getNextLocs(lts, "L5"));
+		Assert.assertEquals(ImmutableSet.of("L7"), getNextLocs(lts, "L6"));
+		Assert.assertEquals(ImmutableSet.of(), getNextLocs(lts, "L7"));
+	}
+
+	@Test
+	public void testLbe1() {
+		CfaLbeLts lts = new CfaLbeLts(getLocByName("L7"));
+		Assert.assertEquals(ImmutableSet.of("L1"), getNextLocs(lts, "L0"));
+		Assert.assertEquals(ImmutableSet.of("L4"), getNextLocs(lts, "L1"));
+		Assert.assertEquals(ImmutableSet.of("L4"), getNextLocs(lts, "L2"));
+		Assert.assertEquals(ImmutableSet.of("L4"), getNextLocs(lts, "L3"));
+		Assert.assertEquals(ImmutableSet.of("L5"), getNextLocs(lts, "L4"));
+		Assert.assertEquals(ImmutableSet.of("L1", "L7"), getNextLocs(lts, "L5"));
+		Assert.assertEquals(ImmutableSet.of("L7"), getNextLocs(lts, "L6"));
+		Assert.assertEquals(ImmutableSet.of(), getNextLocs(lts, "L7"));
+	}
+
+	@Test
+	public void testLbe2() {
+		CfaLbeLts lts = new CfaLbeLts(getLocByName("L3"));
+		Assert.assertEquals(ImmutableSet.of("L1"), getNextLocs(lts, "L0"));
+		Assert.assertEquals(ImmutableSet.of("L3", "L4"), getNextLocs(lts, "L1"));
+		Assert.assertEquals(ImmutableSet.of("L3"), getNextLocs(lts, "L2"));
+		Assert.assertEquals(ImmutableSet.of("L4"), getNextLocs(lts, "L3"));
+		Assert.assertEquals(ImmutableSet.of("L5"), getNextLocs(lts, "L4"));
+		Assert.assertEquals(ImmutableSet.of("L1", "L7"), getNextLocs(lts, "L5"));
+		Assert.assertEquals(ImmutableSet.of("L7"), getNextLocs(lts, "L6"));
+		Assert.assertEquals(ImmutableSet.of(), getNextLocs(lts, "L7"));
+	}
+}

--- a/subprojects/cfa-analysis/src/test/java/hu/bme/mit/theta/cfa/analysis/EncodingTest.java
+++ b/subprojects/cfa-analysis/src/test/java/hu/bme/mit/theta/cfa/analysis/EncodingTest.java
@@ -1,8 +1,6 @@
 package hu.bme.mit.theta.cfa.analysis;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import hu.bme.mit.theta.analysis.State;
 import hu.bme.mit.theta.analysis.expr.ExprState;
 import hu.bme.mit.theta.cfa.CFA;
 import hu.bme.mit.theta.cfa.analysis.lts.CfaLbeLts;
@@ -17,9 +15,7 @@ import org.junit.Test;
 
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 public class EncodingTest {

--- a/subprojects/cfa-analysis/src/test/java/hu/bme/mit/theta/cfa/analysis/impact/CfaPredImpactCheckerTest.java
+++ b/subprojects/cfa-analysis/src/test/java/hu/bme/mit/theta/cfa/analysis/impact/CfaPredImpactCheckerTest.java
@@ -46,7 +46,7 @@ public final class CfaPredImpactCheckerTest {
 
 		final ItpSolver solver = Z3SolverFactory.getInstance().createItpSolver();
 
-		final PredImpactChecker checker = PredImpactChecker.create(CfaLbeLts.getInstance(), cfa.getInitLoc(),
+		final PredImpactChecker checker = PredImpactChecker.create(new CfaLbeLts(cfa.getErrorLoc().get()), cfa.getInitLoc(),
 				l -> l.equals(cfa.getErrorLoc().get()), solver);
 
 		// Act

--- a/subprojects/cfa-analysis/src/test/java/hu/bme/mit/theta/cfa/analysis/impact/CfaPredImpactCheckerTest.java
+++ b/subprojects/cfa-analysis/src/test/java/hu/bme/mit/theta/cfa/analysis/impact/CfaPredImpactCheckerTest.java
@@ -47,7 +47,7 @@ public final class CfaPredImpactCheckerTest {
 		final ItpSolver solver = Z3SolverFactory.getInstance().createItpSolver();
 
 		final PredImpactChecker checker = PredImpactChecker.create(CfaLbeLts.getInstance(), cfa.getInitLoc(),
-				l -> l.equals(cfa.getErrorLoc()), solver);
+				l -> l.equals(cfa.getErrorLoc().get()), solver);
 
 		// Act
 		final SafetyResult<? extends ExprState, ? extends ExprAction> status = checker.check(UnitPrec.getInstance());

--- a/subprojects/cfa-analysis/src/test/java/hu/bme/mit/theta/cfa/analysis/impact/CfaPredImpactCheckerTest.java
+++ b/subprojects/cfa-analysis/src/test/java/hu/bme/mit/theta/cfa/analysis/impact/CfaPredImpactCheckerTest.java
@@ -46,7 +46,7 @@ public final class CfaPredImpactCheckerTest {
 
 		final ItpSolver solver = Z3SolverFactory.getInstance().createItpSolver();
 
-		final PredImpactChecker checker = PredImpactChecker.create(new CfaLbeLts(cfa.getErrorLoc().get()), cfa.getInitLoc(),
+		final PredImpactChecker checker = PredImpactChecker.create(CfaLbeLts.of(cfa.getErrorLoc().get()), cfa.getInitLoc(),
 				l -> l.equals(cfa.getErrorLoc().get()), solver);
 
 		// Act

--- a/subprojects/cfa-analysis/src/test/resources/block-encoding.cfa
+++ b/subprojects/cfa-analysis/src/test/resources/block-encoding.cfa
@@ -1,0 +1,20 @@
+main process cfa {
+	init loc L0
+	loc L1
+	loc L2
+	loc L3
+	loc L4
+	loc L5
+	loc L6
+	loc L7
+	
+	L0 -> L1 { }
+	L1 -> L2 { }
+	L2 -> L3 { }
+	L3 -> L4 { }
+	L1 -> L4 { }
+	L4 -> L5 { }
+	L5 -> L6 { }
+	L6 -> L7 { }
+	L5 -> L1 { }
+}

--- a/subprojects/cfa-cli/README.md
+++ b/subprojects/cfa-cli/README.md
@@ -46,7 +46,7 @@ Note that the model must be given as the first positional argument (without `--m
 All arguments are optional, except `--model`.
 
 * `--model`: Path of the input CFA model (mandatory).
-* `--targetloc`: Name of the target (error) location in the CFA, which is checked for reachability. The CFA is safe if the target location is not reachable, and unsafe otherwise. This argument can be omitted if a location in the CFA is marked with the error keyword. If there is an error location marked in the CFA and this argument is also given, the argument has priority.
+* `--errorloc`: Name of the error (target) location in the CFA, which is checked for reachability. The CFA is safe if the error location is not reachable, and unsafe otherwise. This argument can be omitted if a location in the CFA is marked with the error keyword. If there is an error location marked in the CFA and this argument is also given, the argument has priority.
 * `--cex`: Output file where the counterexample is written (if the result is unsafe). If the argument is not given (default) the counterexample is not printed. Use `CON` (Windows) or `/dev/stdout` (Linux) as argument to print to the standard output.
 * `--loglevel`: Detailedness of logging.
     * Possible values (from the least to the most detailed): `RESULT`, `MAINSTEP`, `SUBSTEP` (default), `INFO`, `DETAIL`, `VERBOSE`.

--- a/subprojects/cfa-cli/README.md
+++ b/subprojects/cfa-cli/README.md
@@ -1,6 +1,6 @@
 ## Overview
 
-The `cfa-cli` project is an executable (command line) tool for running CEGAR-based analyses on CFAs.
+The `cfa-cli` project is an executable (command line) tool for running CEGAR-based location-reachability analyses on CFAs.
 Furthermore, it also includes some utilities, such as calculating metrics or visualizing the CFA.
 For more information about the CFA formalism and its supported language elements, take a look at the [`cfa`](../cfa/README.md) project.
 
@@ -46,6 +46,7 @@ Note that the model must be given as the first positional argument (without `--m
 All arguments are optional, except `--model`.
 
 * `--model`: Path of the input CFA model (mandatory).
+* `--targetloc`: Name of the target (error) location in the CFA, which is checked for reachability. The CFA is safe if the target location is not reachable, and unsafe otherwise. This argument can be omitted if a location in the CFA is marked with the error keyword. If there is an error location marked in the CFA and this argument is also given, the argument has priority.
 * `--cex`: Output file where the counterexample is written (if the result is unsafe). If the argument is not given (default) the counterexample is not printed. Use `CON` (Windows) or `/dev/stdout` (Linux) as argument to print to the standard output.
 * `--loglevel`: Detailedness of logging.
     * Possible values (from the least to the most detailed): `RESULT`, `MAINSTEP`, `SUBSTEP` (default), `INFO`, `DETAIL`, `VERBOSE`.

--- a/subprojects/cfa-cli/src/main/java/hu/bme/mit/theta/cfa/cli/CfaCli.java
+++ b/subprojects/cfa-cli/src/main/java/hu/bme/mit/theta/cfa/cli/CfaCli.java
@@ -86,8 +86,8 @@ public class CfaCli {
 	@Parameter(names = "--model", description = "Path of the input CFA model", required = true)
 	String model;
 
-	@Parameter(names = "--targetloc", description = "Target (error) location")
-	String targetLoc = "";
+	@Parameter(names = "--errorloc", description = "Error (target) location")
+	String errorLoc = "";
 
 	@Parameter(names = "--precgranularity", description = "Precision granularity")
 	PrecGranularity precGranularity = PrecGranularity.GLOBAL;
@@ -180,14 +180,14 @@ public class CfaCli {
 			if (cfa.getErrorLoc().isPresent()) {
 				errLoc = cfa.getErrorLoc().get();
 			}
-			if (!targetLoc.isEmpty()) {
+			if (!errorLoc.isEmpty()) {
 				errLoc = null;
 				for (CFA.Loc running : cfa.getLocs()) {
-					if (running.getName().equals(targetLoc)) {
+					if (running.getName().equals(errorLoc)) {
 						errLoc = running;
 					}
 				}
-				checkNotNull(errLoc, "Location '" + targetLoc + "' not found in CFA");
+				checkNotNull(errLoc, "Location '" + errorLoc + "' not found in CFA");
 			}
 
 			checkNotNull(errLoc, "Error location must be specified in CFA or as argument");

--- a/subprojects/cfa/README.md
+++ b/subprojects/cfa/README.md
@@ -15,7 +15,7 @@ The project contains:
 A CFA is a directed graph (`V`, `L`, `E`) with
 
 * variables `V = {v1, v2, ..., vn}`,
-* locations `L`, with dedicated initial (`l0`), final (`lf`) and error (`le`) locations,
+* locations `L`, with a dedicated initial (`l0`) location and optionally with dedicated final (`lf`) and error (`le`) locations,
 * edges `E` between locations, labeled with statements over the variables.
 
 Currently, there are three kind of supported statements.
@@ -30,7 +30,7 @@ After the assumption, variables are unchanged.
 After performing the havoc, `v` is assigned a non-deterministic value.
 This can be used to simulate non-deterministic input from the user or the environment.
 
-Algorithms are usually interested in proving that the error location is not reachable.
+Algorithms are usually interested in proving that the error location (given in the CFA or as a separate argument) is not reachable.
 For more information see Section 2.1 of [our JAR paper](https://link.springer.com/content/pdf/10.1007%2Fs10817-019-09535-x.pdf).
 
 Variables of the CFA can have the following types.

--- a/subprojects/cfa/src/main/java/hu/bme/mit/theta/cfa/dsl/CfaProcessSymbol.java
+++ b/subprojects/cfa/src/main/java/hu/bme/mit/theta/cfa/dsl/CfaProcessSymbol.java
@@ -130,18 +130,26 @@ final class CfaProcessSymbol implements Symbol, Scope {
 		final List<CfaLocationSymbol> result = new ArrayList<>();
 
 		int nInitLocs = 0;
+		int nFinalLocs = 0;
+		int nErrorLocs = 0;
 
 		for (final LocContext locContext : locContexts) {
 			final CfaLocationSymbol symbol = new CfaLocationSymbol(locContext);
 
 			if (symbol.isInit()) {
 				nInitLocs++;
+			} else if (symbol.isFinal()) {
+				nFinalLocs++;
+			} else if (symbol.isError()) {
+				nErrorLocs++;
 			}
 
 			result.add(symbol);
 		}
 
-		checkArgument(nInitLocs == 1, "Exactly one initial location must be specififed");
+		checkArgument(nInitLocs == 1, "Exactly one initial location must be specified");
+		checkArgument(nFinalLocs <= 1, "At most one final location must be specified");
+		checkArgument(nErrorLocs <= 1, "At most one error location must be specified");
 
 		return result;
 	}

--- a/subprojects/cfa/src/main/java/hu/bme/mit/theta/cfa/dsl/CfaProcessSymbol.java
+++ b/subprojects/cfa/src/main/java/hu/bme/mit/theta/cfa/dsl/CfaProcessSymbol.java
@@ -130,26 +130,18 @@ final class CfaProcessSymbol implements Symbol, Scope {
 		final List<CfaLocationSymbol> result = new ArrayList<>();
 
 		int nInitLocs = 0;
-		int nFinalLocs = 0;
-		int nErrorLocs = 0;
 
 		for (final LocContext locContext : locContexts) {
 			final CfaLocationSymbol symbol = new CfaLocationSymbol(locContext);
 
 			if (symbol.isInit()) {
 				nInitLocs++;
-			} else if (symbol.isFinal()) {
-				nFinalLocs++;
-			} else if (symbol.isError()) {
-				nErrorLocs++;
 			}
 
 			result.add(symbol);
 		}
 
 		checkArgument(nInitLocs == 1, "Exactly one initial location must be specififed");
-		checkArgument(nFinalLocs == 1, "Exactly one final location must be specififed");
-		checkArgument(nErrorLocs == 1, "Exactly one error location must be specififed");
 
 		return result;
 	}

--- a/subprojects/cfa/src/main/java/hu/bme/mit/theta/cfa/dsl/CfaWriter.java
+++ b/subprojects/cfa/src/main/java/hu/bme/mit/theta/cfa/dsl/CfaWriter.java
@@ -50,13 +50,13 @@ public final class CfaWriter {
 		for (final Loc loc : cfa.getLocs()) {
 			final String locName = "L" + loc.getName();
 			String locPrefix = "";
-			if (loc == cfa.getErrorLoc()) {
+			if (cfa.getErrorLoc().isPresent() && loc == cfa.getErrorLoc().get()) {
 				locPrefix += "error ";
 			}
 			if (loc == cfa.getInitLoc()) {
 				locPrefix += "init ";
 			}
-			if (loc == cfa.getFinalLoc()) {
+			if (cfa.getFinalLoc().isPresent() && loc == cfa.getFinalLoc().get()) {
 				locPrefix += "final ";
 			}
 			bw.write(String.format("\t%sloc %s", locPrefix, locName));


### PR DESCRIPTION
This PR makes the final/error locations of the CFA optional. The motivation behind this is that (1) not all algorithms are interested in them, and (2) sometimes it can be desirable to check multiple queries for the same CFA. The CLI tool was extended in a way that it can accept a `--targetloc` argument. If the argument is given, that location is treated as error, otherwise we fallback to the old solution, namely looking for the error loc in the CFA. This makes the solution backward compatible. See #29 for more information

@as3810t Can you play around a bit with this version?