### PR TITLE
Implement reset in Z3 solver

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ buildscript {
 
 allprojects {
     group = "hu.bme.mit.inf.theta"
-    version = "2.7.0"
+    version = "2.7.1"
 
     apply(from = rootDir.resolve("gradle/shared-with-buildSrc/mirrors.gradle.kts"))
 }

--- a/subprojects/solver-z3/src/main/java/hu/bme/mit/theta/solver/z3/Z3DeclTransformer.java
+++ b/subprojects/solver-z3/src/main/java/hu/bme/mit/theta/solver/z3/Z3DeclTransformer.java
@@ -82,7 +82,7 @@ final class Z3DeclTransformer {
 			final Type paramType = funcType.getParamType();
 			final Type resultType = funcType.getResultType();
 
-			checkArgument(!(paramType instanceof FuncType));
+			checkArgument(!(paramType instanceof FuncType), "Parameter type most not be function");
 
 			final Tuple2<List<Type>, Type> subResult = extractTypes(resultType);
 			final List<Type> paramTypes = subResult.get1();

--- a/subprojects/solver-z3/src/main/java/hu/bme/mit/theta/solver/z3/Z3ExprTransformer.java
+++ b/subprojects/solver-z3/src/main/java/hu/bme/mit/theta/solver/z3/Z3ExprTransformer.java
@@ -928,4 +928,8 @@ final class Z3ExprTransformer {
 		}
 	}
 
+	public void reset() {
+		exprToTerm.invalidateAll();
+	}
+
 }

--- a/subprojects/solver-z3/src/main/java/hu/bme/mit/theta/solver/z3/Z3ExprTransformer.java
+++ b/subprojects/solver-z3/src/main/java/hu/bme/mit/theta/solver/z3/Z3ExprTransformer.java
@@ -321,7 +321,7 @@ final class Z3ExprTransformer {
 		try {
 			return exprToTerm.get(expr, () -> table.dispatch(expr));
 		} catch (final ExecutionException e) {
-			throw new AssertionError();
+			throw new AssertionError("Unhandled case: " + expr, e);
 		}
 	}
 

--- a/subprojects/solver-z3/src/main/java/hu/bme/mit/theta/solver/z3/Z3ItpSolver.java
+++ b/subprojects/solver-z3/src/main/java/hu/bme/mit/theta/solver/z3/Z3ItpSolver.java
@@ -79,7 +79,7 @@ final class Z3ItpSolver implements ItpSolver {
 	public void add(final ItpMarker marker, final Expr<BoolType> assertion) {
 		checkNotNull(marker);
 		checkNotNull(assertion);
-		checkArgument(markers.toCollection().contains(marker));
+		checkArgument(markers.toCollection().contains(marker), "Marker not found in solver");
 		final Z3ItpMarker z3Marker = (Z3ItpMarker) marker;
 		final com.microsoft.z3.BoolExpr term = (com.microsoft.z3.BoolExpr) transformationManager.toTerm(assertion);
 		solver.add(assertion, term);

--- a/subprojects/solver-z3/src/main/java/hu/bme/mit/theta/solver/z3/Z3Solver.java
+++ b/subprojects/solver-z3/src/main/java/hu/bme/mit/theta/solver/z3/Z3Solver.java
@@ -147,6 +147,7 @@ final class Z3Solver implements Solver {
 		assertions.clear();
 		assumptions.clear();
 		symbolTable.clear();
+		transformationManager.reset();
 		clearState();
 	}
 

--- a/subprojects/solver-z3/src/main/java/hu/bme/mit/theta/solver/z3/Z3Solver.java
+++ b/subprojects/solver-z3/src/main/java/hu/bme/mit/theta/solver/z3/Z3Solver.java
@@ -143,7 +143,11 @@ final class Z3Solver implements Solver {
 
 	@Override
 	public void reset() {
-		throw new UnsupportedOperationException();
+		z3Solver.reset();
+		assertions.clear();
+		assumptions.clear();
+		symbolTable.clear();
+		clearState();
 	}
 
 	@Override

--- a/subprojects/solver-z3/src/main/java/hu/bme/mit/theta/solver/z3/Z3SymbolTable.java
+++ b/subprojects/solver-z3/src/main/java/hu/bme/mit/theta/solver/z3/Z3SymbolTable.java
@@ -58,4 +58,8 @@ final class Z3SymbolTable {
 		constToSymbol.put(constDecl, symbol);
 	}
 
+	public void clear() {
+		constToSymbol.clear();
+	}
+
 }

--- a/subprojects/solver-z3/src/main/java/hu/bme/mit/theta/solver/z3/Z3SymbolTable.java
+++ b/subprojects/solver-z3/src/main/java/hu/bme/mit/theta/solver/z3/Z3SymbolTable.java
@@ -42,19 +42,19 @@ final class Z3SymbolTable {
 	}
 
 	public com.microsoft.z3.FuncDecl getSymbol(final ConstDecl<?> constDecl) {
-		checkArgument(definesConst(constDecl));
+		checkArgument(definesConst(constDecl), "Declaration " + constDecl + " not found in symbol table");
 		return constToSymbol.get(constDecl);
 	}
 
 	public ConstDecl<?> getConst(final com.microsoft.z3.FuncDecl symbol) {
-		checkArgument(definesSymbol(symbol));
+		checkArgument(definesSymbol(symbol), "Symbol " + symbol + " not found in symbol table");
 		return constToSymbol.inverse().get(symbol);
 	}
 
 	public void put(final ConstDecl<?> constDecl, final com.microsoft.z3.FuncDecl symbol) {
 		checkNotNull(constDecl);
 		checkNotNull(symbol);
-		checkState(!constToSymbol.containsKey(constDecl), "Constant not found.");
+		checkState(!constToSymbol.containsKey(constDecl), "Constant " + constDecl + " not found.");
 		constToSymbol.put(constDecl, symbol);
 	}
 

--- a/subprojects/solver-z3/src/main/java/hu/bme/mit/theta/solver/z3/Z3TermTransformer.java
+++ b/subprojects/solver-z3/src/main/java/hu/bme/mit/theta/solver/z3/Z3TermTransformer.java
@@ -383,7 +383,7 @@ final class Z3TermTransformer {
 			final Supplier<Expr<?>> function) {
 		return (term, model, vars) -> {
 			final com.microsoft.z3.Expr[] args = term.getArgs();
-			checkArgument(args.length == 0);
+			checkArgument(args.length == 0, "Number of arguments must be zero");
 			return function.get();
 		};
 	}
@@ -392,7 +392,7 @@ final class Z3TermTransformer {
 			final UnaryOperator<Expr<?>> function) {
 		return (term, model, vars) -> {
 			final com.microsoft.z3.Expr[] args = term.getArgs();
-			checkArgument(args.length == 1);
+			checkArgument(args.length == 1, "Number of arguments must be one");
 			final Expr<?> op = transform(args[0], model, vars);
 			return function.apply(op);
 		};
@@ -402,7 +402,7 @@ final class Z3TermTransformer {
 			final BinaryOperator<Expr<?>> function) {
 		return (term, model, vars) -> {
 			final com.microsoft.z3.Expr[] args = term.getArgs();
-			checkArgument(args.length == 2);
+			checkArgument(args.length == 2, "Number of arguments must be two");
 			final Expr<?> op1 = transform(args[0], model, vars);
 			final Expr<?> op2 = transform(args[1], model, vars);
 			return function.apply(op1, op2);
@@ -413,7 +413,7 @@ final class Z3TermTransformer {
 			final TernaryOperator<Expr<?>> function) {
 		return (term, model, vars) -> {
 			final com.microsoft.z3.Expr[] args = term.getArgs();
-			checkArgument(args.length == 3);
+			checkArgument(args.length == 3, "Number of arguments must be three");
 			final Expr<?> op1 = transform(args[0], model, vars);
 			final Expr<?> op2 = transform(args[1], model, vars);
 			final Expr<?> op3 = transform(args[1], model, vars);

--- a/subprojects/solver-z3/src/main/java/hu/bme/mit/theta/solver/z3/Z3TransformationManager.java
+++ b/subprojects/solver-z3/src/main/java/hu/bme/mit/theta/solver/z3/Z3TransformationManager.java
@@ -45,4 +45,9 @@ final class Z3TransformationManager {
 		return exprTransformer.toTerm(expr);
 	}
 
+	public void reset() {
+		typeTransformer.reset();
+		// declTransformer does not have to be resetted
+		exprTransformer.reset();
+	}
 }

--- a/subprojects/solver-z3/src/main/java/hu/bme/mit/theta/solver/z3/Z3TypeTransformer.java
+++ b/subprojects/solver-z3/src/main/java/hu/bme/mit/theta/solver/z3/Z3TypeTransformer.java
@@ -73,8 +73,12 @@ final class Z3TypeTransformer {
 			final com.microsoft.z3.Sort elemSort = toSort(arrayType.getElemType());
 			return context.mkArraySort(indexSort, elemSort);
 		} else {
-			throw new UnsupportedOperationException();
+			throw new UnsupportedOperationException("Unsupporte type: " + type.getClass().getSimpleName());
 		}
+	}
+
+	public void reset() {
+		bvSorts.clear();
 	}
 
 }

--- a/subprojects/solver-z3/src/test/java/hu/bme/mit/theta/solver/z3/Z3SolverTest.java
+++ b/subprojects/solver-z3/src/test/java/hu/bme/mit/theta/solver/z3/Z3SolverTest.java
@@ -176,6 +176,16 @@ public final class Z3SolverTest {
 		assertTrue(status.isSat());
 	}
 
+	@Test(expected = IllegalArgumentException.class)
+	public void testResetStack() {
+		final Solver solver = Z3SolverFactory.getInstance().createSolver();
+		solver.push();
+		solver.push();
+		solver.pop();
+		solver.reset();
+		solver.pop();
+	}
+
 	@Test
 	public void testBV1() {
 		final Solver solver = Z3SolverFactory.getInstance().createSolver();

--- a/subprojects/solver-z3/src/test/java/hu/bme/mit/theta/solver/z3/Z3SolverTest.java
+++ b/subprojects/solver-z3/src/test/java/hu/bme/mit/theta/solver/z3/Z3SolverTest.java
@@ -37,6 +37,7 @@ import hu.bme.mit.theta.core.type.bvtype.BvExprs;
 import hu.bme.mit.theta.core.type.bvtype.BvLitExpr;
 import hu.bme.mit.theta.core.type.bvtype.BvType;
 import hu.bme.mit.theta.core.type.functype.FuncType;
+import hu.bme.mit.theta.core.type.inttype.IntEqExpr;
 import hu.bme.mit.theta.core.type.inttype.IntExprs;
 import hu.bme.mit.theta.core.type.inttype.IntType;
 import hu.bme.mit.theta.core.utils.BvUtils;
@@ -149,6 +150,30 @@ public final class Z3SolverTest {
 		assertEquals(2, valLit.getElements().size());
 		assertEquals(Int(1), Read(valLit, Int(0)).eval(ImmutableValuation.empty()));
 		assertEquals(Int(2), Read(valLit, Int(1)).eval(ImmutableValuation.empty()));
+	}
+
+	@Test
+	public void testReset() {
+		final Solver solver = Z3SolverFactory.getInstance().createSolver();
+
+		final ConstDecl<IntType> cx = Const("x", Int());
+		final ConstDecl<IntType> cy = Const("y", Int());
+
+		IntEqExpr eqExpr = IntExprs.Eq(cx.getRef(), IntExprs.Add(cy.getRef(), Int(1)));
+		solver.add(eqExpr);
+		SolverStatus status = solver.check();
+		assertTrue(status.isSat());
+
+		solver.add(IntExprs.Lt(cx.getRef(), cy.getRef()));
+		status = solver.check();
+		assertTrue(status.isUnsat());
+
+		solver.reset();
+		assertEquals(0, solver.getAssertions().size());
+
+		solver.add(eqExpr);
+		status = solver.check();
+		assertTrue(status.isSat());
 	}
 
 	@Test

--- a/subprojects/solver-z3/src/test/java/hu/bme/mit/theta/solver/z3/Z3SolverTest.java
+++ b/subprojects/solver-z3/src/test/java/hu/bme/mit/theta/solver/z3/Z3SolverTest.java
@@ -43,6 +43,7 @@ import hu.bme.mit.theta.core.type.inttype.IntType;
 import hu.bme.mit.theta.core.utils.BvUtils;
 import hu.bme.mit.theta.solver.Solver;
 import hu.bme.mit.theta.solver.SolverStatus;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.math.BigInteger;
@@ -61,11 +62,15 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public final class Z3SolverTest {
+	private Solver solver;
+
+	@Before
+	public void setup() {
+		solver = Z3SolverFactory.getInstance().createSolver();
+	}
 
 	@Test
 	public void testSimple() {
-		final Solver solver = Z3SolverFactory.getInstance().createSolver();
-
 		// Create two integer constants x and y
 		final ConstDecl<IntType> cx = Const("x", Int());
 		final ConstDecl<IntType> cy = Const("y", Int());
@@ -87,8 +92,6 @@ public final class Z3SolverTest {
 
 	@Test
 	public void testTrack() {
-		final Solver solver = Z3SolverFactory.getInstance().createSolver();
-
 		final ConstDecl<BoolType> ca = Const("a", BoolExprs.Bool());
 		final Expr<BoolType> expr = BoolExprs.And(ca.getRef(), True());
 
@@ -109,7 +112,6 @@ public final class Z3SolverTest {
 	@Test
 	public void testFunc() {
 		// Arrange
-		final Solver solver = Z3SolverFactory.getInstance().createSolver();
 		final ConstDecl<FuncType<IntType, IntType>> ca = Const("a", Func(Int(), Int()));
 		final Expr<FuncType<IntType, IntType>> a = ca.getRef();
 		final ParamDecl<IntType> px = Param("x", Int());
@@ -131,8 +133,6 @@ public final class Z3SolverTest {
 
 	@Test
 	public void testArray() {
-		final Solver solver = Z3SolverFactory.getInstance().createSolver();
-
         final ConstDecl<ArrayType<IntType, IntType>> arr = Const("arr", Array(Int(), Int()));
 
         solver.add(ArrayExprs.Eq(Write(arr.getRef(), Int(0), Int(1)), arr.getRef()));
@@ -154,8 +154,6 @@ public final class Z3SolverTest {
 
 	@Test
 	public void testReset() {
-		final Solver solver = Z3SolverFactory.getInstance().createSolver();
-
 		final ConstDecl<IntType> cx = Const("x", Int());
 		final ConstDecl<IntType> cy = Const("y", Int());
 
@@ -178,7 +176,6 @@ public final class Z3SolverTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testResetStack() {
-		final Solver solver = Z3SolverFactory.getInstance().createSolver();
 		solver.push();
 		solver.push();
 		solver.pop();
@@ -188,8 +185,6 @@ public final class Z3SolverTest {
 
 	@Test
 	public void testBV1() {
-		final Solver solver = Z3SolverFactory.getInstance().createSolver();
-
 		final ConstDecl<BvType> cx = Const("x", BvType(4));
 		final ConstDecl<BvType> cy = Const("y", BvType(4));
 
@@ -207,8 +202,6 @@ public final class Z3SolverTest {
 
 	@Test
 	public void testBV2() {
-		final Solver solver = Z3SolverFactory.getInstance().createSolver();
-
 		final ConstDecl<BvType> cx = Const("x", BvType(4));
 		final ConstDecl<BvType> cz = Const("z", BvType(4));
 
@@ -229,8 +222,6 @@ public final class Z3SolverTest {
 
 	@Test
 	public void testBV3() {
-		final Solver solver = Z3SolverFactory.getInstance().createSolver();
-
 		final ConstDecl<BvType> cx = Const("x", BvType(4));
 		final ConstDecl<BvType> cy = Const("y", BvType(4));
 
@@ -251,8 +242,6 @@ public final class Z3SolverTest {
 
 	@Test
 	public void testBV4() {
-		final Solver solver = Z3SolverFactory.getInstance().createSolver();
-
 		final ConstDecl<BvType> cx = Const("x", BvType(4));
 		final ConstDecl<BvType> cy = Const("y", BvType(4));
 
@@ -273,8 +262,6 @@ public final class Z3SolverTest {
 
 	@Test
 	public void testBV5() {
-		final Solver solver = Z3SolverFactory.getInstance().createSolver();
-
 		final ConstDecl<BvType> cx = Const("x", BvType(4));
 		final ConstDecl<BvType> cy = Const("y", BvType(4));
 
@@ -295,8 +282,6 @@ public final class Z3SolverTest {
 
 	@Test
 	public void testBV6() {
-		final Solver solver = Z3SolverFactory.getInstance().createSolver();
-
 		final ConstDecl<BvType> cx = Const("x", BvType(4));
 		final ConstDecl<BvType> cy = Const("y", BvType(4));
 
@@ -317,8 +302,6 @@ public final class Z3SolverTest {
 
 	@Test
 	public void testBV7() {
-		final Solver solver = Z3SolverFactory.getInstance().createSolver();
-
 		final ConstDecl<BvType> cx = Const("x", BvType(4));
 		final ConstDecl<BvType> cy = Const("y", BvType(4));
 
@@ -339,8 +322,6 @@ public final class Z3SolverTest {
 
 	@Test
 	public void testBV8() {
-		final Solver solver = Z3SolverFactory.getInstance().createSolver();
-
 		final ConstDecl<BvType> cx = Const("x", BvType(4));
 		final ConstDecl<BvType> cy = Const("y", BvType(4));
 
@@ -361,8 +342,6 @@ public final class Z3SolverTest {
 
 	@Test
 	public void testBV9() {
-		final Solver solver = Z3SolverFactory.getInstance().createSolver();
-
 		final ConstDecl<BvType> cx = Const("x", BvType(4));
 		final ConstDecl<BvType> cy = Const("y", BvType(4));
 
@@ -383,8 +362,6 @@ public final class Z3SolverTest {
 
 	@Test
 	public void testBV10() {
-		final Solver solver = Z3SolverFactory.getInstance().createSolver();
-
 		final ConstDecl<BvType> cx = Const("x", BvType(4));
 		final ConstDecl<BvType> cy = Const("y", BvType(4));
 
@@ -405,8 +382,6 @@ public final class Z3SolverTest {
 
 	@Test
 	public void testBV11() {
-		final Solver solver = Z3SolverFactory.getInstance().createSolver();
-
 		final ConstDecl<BvType> cx = Const("x", BvType(4));
 		final ConstDecl<BvType> cy = Const("y", BvType(4));
 
@@ -427,8 +402,6 @@ public final class Z3SolverTest {
 
 	@Test
 	public void testBV12() {
-		final Solver solver = Z3SolverFactory.getInstance().createSolver();
-
 		final ConstDecl<BvType> cx = Const("x", BvType(4));
 		final ConstDecl<BvType> cy = Const("y", BvType(4));
 
@@ -448,7 +421,6 @@ public final class Z3SolverTest {
 	}
 
 	public void testBV13() {
-		final Solver solver = Z3SolverFactory.getInstance().createSolver();
 		solver.push();
 
 		solver.add(BvExprs.Eq(uint16ToBvLitExpr(4), BvExprs.Add(List.of(uint16ToBvLitExpr(1), uint16ToBvLitExpr(3)))));
@@ -457,7 +429,6 @@ public final class Z3SolverTest {
 		solver.add(BvExprs.Eq(uint16ToBvLitExpr(4), BvExprs.SDiv(uint16ToBvLitExpr(12), uint16ToBvLitExpr(3))));
 		solver.add(BvExprs.Eq(uint16ToBvLitExpr(1), BvExprs.SMod(uint16ToBvLitExpr(13), uint16ToBvLitExpr(3))));
 		solver.add(BvExprs.Eq(uint16ToBvLitExpr(1), BvExprs.SRem(uint16ToBvLitExpr(13), uint16ToBvLitExpr(3))));
-
 	}
 
 	private static BvLitExpr uint16ToBvLitExpr(int value) {

--- a/subprojects/solver/src/main/java/hu/bme/mit/theta/solver/Solver.java
+++ b/subprojects/solver/src/main/java/hu/bme/mit/theta/solver/Solver.java
@@ -98,7 +98,8 @@ public interface Solver {
 	}
 
 	/**
-	 * Reset the solver state.
+	 * Reset the solver state. It should be only used as a last resort. Try using
+	 * {@link #push()} and {@link #pop()} instead.
 	 */
 	void reset();
 

--- a/subprojects/solver/src/main/java/hu/bme/mit/theta/solver/Solver.java
+++ b/subprojects/solver/src/main/java/hu/bme/mit/theta/solver/Solver.java
@@ -99,7 +99,8 @@ public interface Solver {
 
 	/**
 	 * Reset the solver state. It should be only used as a last resort. Try using
-	 * {@link #push()} and {@link #pop()} instead.
+	 * {@link #push()} and {@link #pop()} instead. See also {@link hu.bme.mit.theta.solver.utils.WithPushPop}
+	 * which implements try with resources pattern.
 	 */
 	void reset();
 

--- a/subprojects/solver/src/main/java/hu/bme/mit/theta/solver/Stack.java
+++ b/subprojects/solver/src/main/java/hu/bme/mit/theta/solver/Stack.java
@@ -33,4 +33,6 @@ public interface Stack<T> extends Iterable<T> {
 
 	Collection<T> toCollection();
 
+	void clear();
+
 }

--- a/subprojects/solver/src/main/java/hu/bme/mit/theta/solver/impl/StackImpl.java
+++ b/subprojects/solver/src/main/java/hu/bme/mit/theta/solver/impl/StackImpl.java
@@ -52,9 +52,9 @@ public class StackImpl<T> implements Stack<T> {
 
 	@Override
 	public void pop(final int n) {
-		checkArgument(n > 0);
+		checkArgument(n > 0, "Number of pops must be positive");
 		final int depth = sizes.size();
-		checkArgument(depth >= n);
+		checkArgument(depth >= n, "Stack not deep enough to pop " + n);
 
 		final int size = sizes.get(depth - n);
 		sizes.subList(depth - n, depth).clear();

--- a/subprojects/solver/src/main/java/hu/bme/mit/theta/solver/impl/StackImpl.java
+++ b/subprojects/solver/src/main/java/hu/bme/mit/theta/solver/impl/StackImpl.java
@@ -71,4 +71,9 @@ public class StackImpl<T> implements Stack<T> {
 		return items.iterator();
 	}
 
+	@Override
+	public void clear() {
+		items.clear();
+		sizes.clear();
+	}
 }

--- a/subprojects/solver/src/test/java/hu/bme/mit/theta/solver/StackTest.java
+++ b/subprojects/solver/src/test/java/hu/bme/mit/theta/solver/StackTest.java
@@ -91,4 +91,16 @@ public class StackTest {
 		stack.pop();
 		stack.pop();
 	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testClear() {
+		final Stack<String> stack = new StackImpl<>();
+
+		stack.push();
+		stack.push();
+		stack.clear();
+		stack.push();
+		stack.pop();
+		stack.pop();
+	}
 }


### PR DESCRIPTION
This PR implements the reset function in the Z3 solver. While it is recommended to instead use push/pop, it can be still useful for quick prototyping. Furthermore, some messages were added to exceptions.

Fixes #92 