### PR TITLE
Fixed typo in Z3TermTransformer

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ buildscript {
 
 allprojects {
     group = "hu.bme.mit.inf.theta"
-    version = "2.9.2"
+    version = "2.9.3"
 
     apply(from = rootDir.resolve("gradle/shared-with-buildSrc/mirrors.gradle.kts"))
 }

--- a/subprojects/common/solver-z3/src/main/java/hu/bme/mit/theta/solver/z3/Z3TermTransformer.java
+++ b/subprojects/common/solver-z3/src/main/java/hu/bme/mit/theta/solver/z3/Z3TermTransformer.java
@@ -418,7 +418,7 @@ final class Z3TermTransformer {
 			checkArgument(args.length == 3, "Number of arguments must be three");
 			final Expr<?> op1 = transform(args[0], model, vars);
 			final Expr<?> op2 = transform(args[1], model, vars);
-			final Expr<?> op3 = transform(args[1], model, vars);
+			final Expr<?> op3 = transform(args[2], model, vars);
 			return function.apply(op1, op2, op3);
 		};
 	}


### PR DESCRIPTION
Fixed a typo in Z3TermTransformer.java which caused errors if the interpolant contained `ArrayWriteExprs`