### PR TITLE
Test-generation feature for XTA

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,6 +18,7 @@ include(
         "xta/xta",
         "xta/xta-analysis",
         "xta/xta-cli",
+        "xta/xta-testgen",
 
         "xsts/xsts",
         "xsts/xsts-analysis",

--- a/subprojects/common/common/src/main/java/hu/bme/mit/theta/common/visualization/NodeAttributes.java
+++ b/subprojects/common/common/src/main/java/hu/bme/mit/theta/common/visualization/NodeAttributes.java
@@ -28,9 +28,10 @@ public final class NodeAttributes {
 	private final int peripheries;
 	private final Shape shape;
 	private final Alignment alignment;
+	private final boolean invisible;
 
 	private NodeAttributes(final String label, final Color lineColor, final Color fillColor, final LineStyle lineStyle,
-						   final String font, final int peripheries, final Shape shape, final Alignment alignment) {
+						   final String font, final int peripheries, final Shape shape, final Alignment alignment, final boolean invisible) {
 		this.label = checkNotNull(label);
 		this.lineColor = checkNotNull(lineColor);
 		this.fillColor = checkNotNull(fillColor);
@@ -39,6 +40,7 @@ public final class NodeAttributes {
 		this.peripheries = peripheries;
 		this.shape = checkNotNull(shape);
 		this.alignment = checkNotNull(alignment);
+		this.invisible = invisible;
 	}
 
 	public String getLabel() {
@@ -73,6 +75,8 @@ public final class NodeAttributes {
 		return alignment;
 	}
 
+	public boolean getInvisible() { return invisible; }
+
 	public static Builder builder() {
 		return new Builder();
 	}
@@ -86,6 +90,7 @@ public final class NodeAttributes {
 		private int peripheries = 1;
 		private Shape shape = Shape.ELLIPSE;
 		private Alignment alignment = Alignment.CENTER;
+		private boolean invisible = false;
 
 		public Builder label(final String label) {
 			this.label = label;
@@ -127,8 +132,13 @@ public final class NodeAttributes {
 			return this;
 		}
 
+		public Builder invisible(final boolean invisible) {
+			this.invisible = invisible;
+			return this;
+		}
+
 		public NodeAttributes build() {
-			return new NodeAttributes(label, lineColor, fillColor, lineStyle, font, peripheries, shape, alignment);
+			return new NodeAttributes(label, lineColor, fillColor, lineStyle, font, peripheries, shape, alignment, invisible);
 		}
 	}
 }

--- a/subprojects/common/common/src/main/java/hu/bme/mit/theta/common/visualization/writer/GraphvizWriter.java
+++ b/subprojects/common/common/src/main/java/hu/bme/mit/theta/common/visualization/writer/GraphvizWriter.java
@@ -149,6 +149,10 @@ public final class GraphvizWriter extends AbstractGraphWriter {
 		}
 		style += "filled";
 
+		if (attributes.getInvisible()) {
+			style = "invis," + style;
+		}
+
 		sb.append("\t\t").append(node.getId());
 		sb.append(" [label=\"").append(convertLabel(attributes.getLabel(), attributes.getAlignment())).append('\"');
 		if (attributes.getPeripheries() > 1) {

--- a/subprojects/xta/xta-analysis/src/main/java/hu/bme/mit/theta/xta/analysis/XtaAction.java
+++ b/subprojects/xta/xta-analysis/src/main/java/hu/bme/mit/theta/xta/analysis/XtaAction.java
@@ -56,7 +56,7 @@ import static hu.bme.mit.theta.xta.Sync.Kind.EMIT;
 
 public abstract class XtaAction extends StmtAction {
 
-	private static final VarDecl<RatType> DELAY = Var("_delay", Rat());
+	public static final VarDecl<RatType> DELAY = Var("_delay", Rat());
 
 	private final Collection<VarDecl<RatType>> clockVars;
 	private final List<Loc> sourceLocs;

--- a/subprojects/xta/xta-analysis/src/main/java/hu/bme/mit/theta/xta/analysis/lazy/LazyXtaTestgenStatistics.java
+++ b/subprojects/xta/xta-analysis/src/main/java/hu/bme/mit/theta/xta/analysis/lazy/LazyXtaTestgenStatistics.java
@@ -1,0 +1,183 @@
+package hu.bme.mit.theta.xta.analysis.lazy;
+
+import com.google.common.base.Stopwatch;
+import hu.bme.mit.theta.analysis.algorithm.Statistics;
+import hu.bme.mit.theta.common.table.TableWriter;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+public class LazyXtaTestgenStatistics extends Statistics {
+	private final LazyXtaStatistics stats;
+
+	private final Stopwatch testgenTimer;
+	private long testCasesGenerated;
+	private long testCases;
+	private long testCasesTotalLength;
+
+	public LazyXtaTestgenStatistics(LazyXtaStatistics stats) {
+		this.stats = stats;
+
+		testgenTimer = Stopwatch.createUnstarted();
+		testCases = 0;
+		testCasesTotalLength = 0;
+		testCasesGenerated = 0;
+
+		addStat("AlgorithmTimeInMs", this::getAlgorithmTimeInMs);
+		addStat("ExpandTimeInMs", this::getExpandTimeInMs);
+		addStat("CloseTimeInMs", this::getCloseTimeInMs);
+		addStat("ExpandExplRefinementTimeInMs", this::getExpandExplRefinementTimeInMs);
+		addStat("ExpandZoneRefinementTimeInMs", this::getExpandZoneRefinementTimeInMs);
+		addStat("CloseExplRefinementTimeInMs", this::getCloseExplRefinementTimeInMs);
+		addStat("CloseZoneRefinementTimeInMs", this::getCloseZoneRefinementTimeInMs);
+		addStat("CoverageChecks", this::getCoverageChecks);
+		addStat("CoverageAttempts", this::getCoverageAttempts);
+		addStat("CoverageSuccesses", this::getCoverageSuccesses);
+		addStat("ExplRefinementSteps", this::getExplRefinementSteps);
+		addStat("ZoneRefinementSteps", this::getZoneRefinementSteps);
+		addStat("ArgDepth", this::getArgDepth);
+		addStat("ArgNodes", this::getArgNodes);
+		addStat("ArgNodesExpanded", this::getArgNodesExpanded);
+
+		addStat("TestCasesGenerated", this::getTestCasesGenerated);
+		addStat("TestgenTimeInMs", this::getTestgenTimeInMs);
+		addStat("TestCases", this::getTestCases);
+		addStat("TestCasesTotalLength", this::getTestCasesTotalLength);
+	}
+
+	public long getAlgorithmTimeInMs() { return stats.getAlgorithmTimeInMs(); }
+
+	public long getExpandTimeInMs() {
+		return stats.getExpandTimeInMs();
+	}
+
+	public long getCloseTimeInMs() {
+		return stats.getCloseTimeInMs();
+	}
+
+	public long getExpandExplRefinementTimeInMs() {
+		return stats.getExpandExplRefinementTimeInMs();
+	}
+
+	public long getExpandZoneRefinementTimeInMs() {
+		return stats.getExpandZoneRefinementTimeInMs();
+	}
+
+	public long getCloseExplRefinementTimeInMs() {
+		return stats.getCloseExplRefinementTimeInMs();
+	}
+
+	public long getCloseZoneRefinementTimeInMs() {
+		return stats.getCloseZoneRefinementTimeInMs();
+	}
+
+	public long getCoverageChecks() {
+		return stats.getCoverageChecks();
+	}
+
+	public long getCoverageAttempts() {
+		return stats.getCoverageAttempts();
+	}
+
+	public long getCoverageSuccesses() {
+		return stats.getCoverageSuccesses();
+	}
+
+	public long getExplRefinementSteps() {
+		return stats.getExplRefinementSteps();
+	}
+
+	public long getZoneRefinementSteps() {
+		return stats.getZoneRefinementSteps();
+	}
+
+	public long getArgDepth() {
+		return stats.getArgDepth();
+	}
+
+	public long getArgNodes() {
+		return stats.getArgNodes();
+	}
+
+	public long getArgNodesExpanded() {
+		return stats.getArgNodesExpanded();
+	}
+
+
+	public long getTestCasesGenerated() { return testCasesGenerated; }
+
+	public long getTestgenTimeInMs() { return testgenTimer.elapsed(MILLISECONDS); }
+
+	public long getTestCases() { return testCases; }
+
+	public long getTestCasesTotalLength() { return testCasesTotalLength; }
+
+	public static void writeHeader(final TableWriter writer) {
+		writer.cell("AlgorithmTimeInMs");
+		writer.cell("ExpandTimeInMs");
+		writer.cell("CloseTimeInMs");
+		writer.cell("ExpandExplRefinementTimeInMs");
+		writer.cell("ExpandZoneRefinementTimeInMs");
+		writer.cell("CloseExplRefinementTimeInMs");
+		writer.cell("CloseZoneRefinementTimeInMs");
+		writer.cell("CoverageChecks");
+		writer.cell("CoverageAttempts");
+		writer.cell("CoverageSuccesses");
+		writer.cell("ExplRefinementSteps");
+		writer.cell("ZoneRefinementSteps");
+		writer.cell("ArgDepth");
+		writer.cell("ArgNodes");
+		writer.cell("ArgNodesExpanded");
+
+		writer.cell("TestCasesGenerated");
+		writer.cell("TestgenTimeInMs");
+		writer.cell("TestCases");
+		writer.cell("TestCasesTotalLength");
+
+		writer.newRow();
+	}
+
+	public void writeData(final TableWriter writer) {
+		writer.cell(getAlgorithmTimeInMs());
+		writer.cell(getExpandTimeInMs());
+		writer.cell(getCloseTimeInMs());
+		writer.cell(getExpandExplRefinementTimeInMs());
+		writer.cell(getExpandZoneRefinementTimeInMs());
+		writer.cell(getCloseExplRefinementTimeInMs());
+		writer.cell(getCloseZoneRefinementTimeInMs());
+		writer.cell(getCoverageChecks());
+		writer.cell(getCoverageAttempts());
+		writer.cell(getCoverageSuccesses());
+		writer.cell(getExplRefinementSteps());
+		writer.cell(getZoneRefinementSteps());
+		writer.cell(getArgDepth());
+		writer.cell(getArgNodes());
+		writer.cell(getArgNodesExpanded());
+
+		writer.cell(testCasesGenerated);
+		writer.cell(getTestgenTimeInMs());
+		writer.cell(testCases);
+		writer.cell(testCasesTotalLength);
+
+		writer.newRow();
+	}
+
+	public void startTestgen() {
+		testgenTimer.start();
+	}
+
+	public void stopTestgen() {
+		testgenTimer.stop();
+	}
+
+	public void testCaseGenerated() {
+		testCasesGenerated++;
+	}
+
+	public void setTestCases(long num) {
+		testCases = num;
+	}
+
+	public void addTestCaseLength(long length) {
+		testCasesTotalLength += length;
+	}
+}

--- a/subprojects/xta/xta-testgen/build.gradle.kts
+++ b/subprojects/xta/xta-testgen/build.gradle.kts
@@ -1,15 +1,9 @@
 plugins {
     id("java-common")
-    id("cli-tool")
 }
 
 dependencies {
     compile(project(":theta-xta"))
     compile(project(":theta-xta-analysis"))
     compile(project(":theta-solver-z3"))
-    compile(project(":theta-xta-testgen"))
-}
-
-application {
-    mainClassName = "hu.bme.mit.theta.xta.cli.XtaCli"
 }

--- a/subprojects/xta/xta-testgen/src/main/java/hu/bme/mit/theta/xta/testgen/XtaTest.java
+++ b/subprojects/xta/xta-testgen/src/main/java/hu/bme/mit/theta/xta/testgen/XtaTest.java
@@ -1,0 +1,52 @@
+package hu.bme.mit.theta.xta.testgen;
+
+import hu.bme.mit.theta.analysis.State;
+import hu.bme.mit.theta.analysis.algorithm.ArgNode;
+import hu.bme.mit.theta.analysis.algorithm.ArgTrace;
+import hu.bme.mit.theta.xta.XtaProcess;
+import hu.bme.mit.theta.xta.analysis.XtaAction;
+import hu.bme.mit.theta.xta.analysis.XtaState;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class XtaTest<S extends XtaState<? extends State>, A extends XtaAction> {
+	private final String name;
+	private List<Double> delays;
+	private final ArgTrace<S, A> trace;
+
+	public XtaTest(String name, List<Double> delays, ArgTrace<S, A> trace) {
+		this.name = name;
+		this.delays = delays;
+		this.trace = trace;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public List<Double> getDelays() {
+		return delays;
+	}
+
+	public void setDelays(List<Double> delays) { this.delays = delays; }
+
+	public ArgTrace<S, A> getTrace() {
+		return trace;
+	}
+
+	public int getLength() { return trace.nodes().size(); }
+
+	public double getTotalTime() {
+		return delays.stream().mapToDouble(Double::doubleValue).sum();
+	}
+
+	public Set<XtaProcess.Loc> getLocs() {
+		Set<XtaProcess.Loc> locs = new HashSet<>();
+		for (ArgNode<S, A> node : trace.nodes()) {
+			locs.addAll(node.getState().getLocs());
+		}
+		return locs;
+	}
+}

--- a/subprojects/xta/xta-testgen/src/main/java/hu/bme/mit/theta/xta/testgen/XtaTestGenerator.java
+++ b/subprojects/xta/xta-testgen/src/main/java/hu/bme/mit/theta/xta/testgen/XtaTestGenerator.java
@@ -1,0 +1,243 @@
+package hu.bme.mit.theta.xta.testgen;
+
+import hu.bme.mit.theta.analysis.algorithm.ARG;
+import hu.bme.mit.theta.analysis.algorithm.ArgNode;
+import hu.bme.mit.theta.analysis.algorithm.ArgTrace;
+import hu.bme.mit.theta.common.logging.Logger;
+import hu.bme.mit.theta.core.decl.ConstDecl;
+import hu.bme.mit.theta.core.decl.Decls;
+import hu.bme.mit.theta.core.decl.IndexedConstDecl;
+import hu.bme.mit.theta.core.model.Valuation;
+import hu.bme.mit.theta.core.type.Expr;
+import hu.bme.mit.theta.core.type.abstracttype.AddExpr;
+import hu.bme.mit.theta.core.type.abstracttype.EqExpr;
+import hu.bme.mit.theta.core.type.abstracttype.LeqExpr;
+import hu.bme.mit.theta.core.type.anytype.RefExpr;
+import hu.bme.mit.theta.core.type.booltype.AndExpr;
+import hu.bme.mit.theta.core.type.booltype.BoolType;
+import hu.bme.mit.theta.core.type.rattype.RatLitExpr;
+import hu.bme.mit.theta.core.type.rattype.RatType;
+import hu.bme.mit.theta.core.utils.PathUtils;
+import hu.bme.mit.theta.core.utils.VarIndexing;
+import hu.bme.mit.theta.solver.Solver;
+import hu.bme.mit.theta.solver.utils.WithPushPop;
+import hu.bme.mit.theta.xta.XtaProcess;
+import hu.bme.mit.theta.xta.XtaSystem;
+import hu.bme.mit.theta.xta.analysis.XtaAction;
+import hu.bme.mit.theta.xta.analysis.XtaState;
+import hu.bme.mit.theta.xta.analysis.lazy.LazyXtaStatistics;
+import hu.bme.mit.theta.xta.analysis.lazy.LazyXtaTestgenStatistics;
+
+import java.math.BigInteger;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public final class XtaTestGenerator<S extends XtaState<?>, A extends XtaAction> {
+	private final ARG<S, A> arg;
+	private final XtaSystem system;
+	private final Solver solver;
+	private final Logger logger;
+	private final LazyXtaTestgenStatistics stats;
+
+	private ConstDecl<RatType> totalTime = null;
+
+	public XtaTestGenerator(ARG<S, A> arg, XtaSystem system, Solver solver, Logger logger, LazyXtaStatistics stats) {
+		this.arg = arg;
+		this.system = system;
+		this.solver = solver;
+		this.logger = logger;
+		this.stats = new LazyXtaTestgenStatistics(stats);
+	}
+
+	public LazyXtaTestgenStatistics getStats() {
+		return stats;
+	}
+
+	public Set<? extends XtaTest<S, A>> generateTests() {
+		stats.startTestgen();
+
+		Map<XtaProcess.Loc, XtaTest<S, A>> locTests = new HashMap<>();
+		int testCnt = 1;
+
+		int locCount = system.getProcesses().stream()
+				.map(p -> p.getLocs().size())
+				.mapToInt(Integer::intValue)
+				.sum();
+
+		Set<ArgNode<S, A>> nodesToProcess = arg.getInitNodes().collect(Collectors.toSet());
+		Set<ArgNode<S, A>> nextNodes = new HashSet<>();
+
+		while (locTests.size() < locCount && !nodesToProcess.isEmpty()) {
+			for (ArgNode<S, A> node : nodesToProcess) {
+				//SPIN 2018 paper Lemma 2.: we have nothing to do with excluded nodes
+				if (node.isExcluded())
+					continue;
+
+				XtaTest<S, A> test = generateTest(node, testCnt++, locTests.keySet());
+				int newLocs = (int) test.getLocs().stream()
+						.filter(l -> !locTests.containsKey(l))
+						.count();
+				if (newLocs > 0) {
+					for (XtaProcess.Loc loc : test.getLocs()) {
+						locTests.put(loc, test);
+					}
+				}
+
+				if (locTests.size() == locCount)
+					break;
+
+				nextNodes.addAll(node.children().collect(Collectors.toList()));
+			}
+			nodesToProcess.clear();
+			nodesToProcess.addAll(nextNodes);
+			nextNodes.clear();
+		}
+
+		var testSet = new HashSet<>(locTests.values());
+		for (var test : testSet) {
+			concretizeTest(test);
+		}
+
+		stats.stopTestgen();
+		stats.setTestCases(testSet.size());
+		testSet.forEach(t -> stats.addTestCaseLength(t.getLength()));
+
+		return testSet;
+	}
+
+	private void concretizeTest(XtaTest<S, A> test) {
+		ArgTrace<S, A> trace = test.getTrace();
+		List<Double> delays = calculateDelays(trace);
+		test.setDelays(delays);
+	}
+
+	private XtaTest<S, A> generateTest(ArgNode<S, A> node, int testCnt, Set<XtaProcess.Loc> doneLocs) {
+		stats.testCaseGenerated();
+
+		ArgTrace<S, A> trace = ArgTrace.to(node);
+		List<XtaProcess.Loc> locs = trace.nodes().stream()
+				.flatMap(n -> n.getState().getLocs().stream())
+				.filter (l -> !doneLocs.contains(l))
+				.collect(Collectors.toList());
+		String locNames = locs.stream().map(XtaProcess.Loc::getName).collect(Collectors.joining("_"));
+		return new XtaTest<>(String.format("TRACE__%d__%s", testCnt, locNames), null, trace);
+	}
+
+	private List<Double> calculateDelays(ArgTrace<S, A> trace) {
+		Double[] delays = new Double[trace.nodes().size()];
+		try (WithPushPop wpp = new WithPushPop(solver)) {
+			int nodeCount = trace.nodes().size();
+			List<VarIndexing> indexing = new ArrayList<>(nodeCount);
+			indexing.add(VarIndexing.all(0));
+
+			addInitialClockConstraints(indexing);
+			addInitialNodeConstraint(trace, indexing);
+
+			assert solver.check().isSat() : "Initial state of the trace is not feasible.";
+
+			addTraceConstraints(trace, indexing);
+			addSumOfDelaysConstraint(trace);
+
+			boolean sat = solver.check().isSat();
+			if (sat) {
+				Valuation bestValuation = reduceDelays();
+				extractDelays(bestValuation, delays);
+			}
+		}
+		return List.of(delays);
+	}
+
+	private void addInitialClockConstraints(List<VarIndexing> indexing) {
+		//initial clock constraints: every clock:0 should equal delay:0
+		List<Expr<BoolType>> clockTerms = new ArrayList<>();
+		RefExpr<RatType> delayRef = RefExpr.of(XtaAction.DELAY);
+		for (var cv : system.getClockVars()) {
+			RefExpr<RatType> clockVarRef = RefExpr.of(cv);
+			clockTerms.add(EqExpr.create2(clockVarRef, delayRef));
+		}
+		Expr<BoolType> initialClockConstraint = PathUtils.unfold(AndExpr.of(clockTerms), indexing.get(0));
+		solver.add(initialClockConstraint);
+	}
+
+	private void addInitialNodeConstraint(ArgTrace<S,A> trace, List<VarIndexing> indexing) {
+		Expr<BoolType> initialConstraint = PathUtils.unfold(trace.nodes().get(0).getState().toExpr(), indexing.get(0));
+		solver.add(initialConstraint);
+	}
+
+	private void addTraceConstraints(ArgTrace<S, A> trace, List<VarIndexing> indexing) {
+		for (int i = 1; i < trace.nodes().size(); i++) {
+			XtaState<?> st = trace.nodes().get(i).getState();
+			XtaAction a = trace.edges().get(i - 1).getAction();
+
+			indexing.add(indexing.get(i - 1).add(a.nextIndexing()));
+
+			Expr<BoolType> actionConstraint = PathUtils.unfold(a.toExpr(), indexing.get(i - 1));
+			solver.add(actionConstraint);
+
+			Expr<BoolType> stateConstraint = PathUtils.unfold(st.toExpr(), indexing.get(i));
+			solver.add(stateConstraint);
+		}
+	}
+
+	private void addSumOfDelaysConstraint(ArgTrace<S,A> trace) {
+		totalTime = Decls.Const("__total__time__", RatType.getInstance());
+		RefExpr<RatType> totalTimeRef = RefExpr.of(totalTime);
+		RefExpr<RatType> delayRef = RefExpr.of(XtaAction.DELAY);
+		List<Expr<RatType>> delayRefs = new ArrayList<>();
+		for (int i = 0; i < trace.nodes().size(); i++) {
+			delayRefs.add(PathUtils.unfold(delayRef, i));
+		}
+		EqExpr<?> totalTimeEq = EqExpr.create2(AddExpr.create2(delayRefs), totalTimeRef);
+		solver.add(totalTimeEq);
+	}
+
+	private Valuation reduceDelays() {
+		RatLitExpr min = RatLitExpr.of(BigInteger.ZERO, BigInteger.ONE);
+		RatLitExpr max = getSolverTotalTime();
+		RatLitExpr newMax = min.add(max.sub(min).div(RatLitExpr.of(BigInteger.TWO, BigInteger.ONE)));
+
+		Valuation bestVal = solver.getModel();
+		logger.write(Logger.Level.INFO, "Current best solution: %f%n", getDoubleValue(max));
+
+		while (max.sub(newMax).geq(RatLitExpr.of(BigInteger.ONE, BigInteger.TWO)).getValue()) {
+			logger.write(Logger.Level.INFO, "Looking for solution between %f and %f%n", getDoubleValue(min), getDoubleValue(newMax));
+			solver.push();
+			Expr<BoolType> newAssertion = LeqExpr.create2(RefExpr.of(totalTime), newMax);
+			solver.add(newAssertion);
+
+			if (solver.check().isSat()) {
+				max = getSolverTotalTime();
+				bestVal = solver.getModel();
+				logger.write(Logger.Level.INFO, "Found better solution: %f%n", getDoubleValue(max));
+			} else {
+				logger.write(Logger.Level.INFO, "Did not find better solution.");
+				min = newMax;
+			}
+			newMax = min.add(max.sub(min).div(RatLitExpr.of(BigInteger.TWO, BigInteger.ONE)));
+			solver.pop();
+		}
+		return bestVal;
+	}
+
+	private RatLitExpr getSolverTotalTime() {
+		return (RatLitExpr) solver.getModel().toMap().get(totalTime);
+	}
+
+	private void extractDelays(Valuation valuation, Double[] delays) {
+		var valMap = valuation.toMap();
+
+		for (var entry : valMap.entrySet()) {
+			if (entry.getKey() instanceof IndexedConstDecl) {
+				IndexedConstDecl<?> icd = (IndexedConstDecl<?>) entry.getKey();
+				if (icd.getVarDecl().equals(XtaAction.DELAY)) {
+					RatLitExpr val = (RatLitExpr) entry.getValue();
+					delays[icd.getIndex()] = getDoubleValue(val);
+				}
+			}
+		}
+	}
+
+	private double getDoubleValue(RatLitExpr rat) {
+		return rat.getNum().doubleValue() / rat.getDenom().doubleValue();
+	}
+}

--- a/subprojects/xta/xta-testgen/src/main/java/hu/bme/mit/theta/xta/testgen/XtaTestPrinter.java
+++ b/subprojects/xta/xta-testgen/src/main/java/hu/bme/mit/theta/xta/testgen/XtaTestPrinter.java
@@ -1,0 +1,30 @@
+package hu.bme.mit.theta.xta.testgen;
+
+import hu.bme.mit.theta.analysis.algorithm.ArgTrace;
+import hu.bme.mit.theta.common.logging.Logger;
+
+import java.util.Set;
+
+public class XtaTestPrinter {
+	public static void printTests(Set<? extends XtaTest<?, ?>> tests, Logger logger) {
+		for (XtaTest<?, ?> test : tests)
+			printTest(test, logger);
+	}
+
+	public static void printTest(XtaTest<?, ?> test, Logger logger) {
+		logger.write(Logger.Level.RESULT, "%n========== %s ==========%n", test.getName());
+		ArgTrace<?,?> trace = test.getTrace();
+
+		printState(test, 0, logger);
+		for (int i = 0; i < trace.edges().size(); i++) {
+			logger.write(Logger.Level.RESULT, trace.edges().get(i).getAction().toString() + "\n");
+			printState(test, i+1, logger);
+		}
+		logger.write(Logger.Level.RESULT, "Total time: %f%n", test.getTotalTime());
+	}
+
+	private static void printState(XtaTest<?, ?> test, int idx, Logger logger) {
+		logger.write(Logger.Level.RESULT, test.getTrace().nodes().get(idx).getState().toString() + "\n");
+		logger.write(Logger.Level.RESULT, "Delay: %f%n", test.getDelays().get(idx));
+	}
+}

--- a/subprojects/xta/xta-testgen/src/main/java/hu/bme/mit/theta/xta/testgen/XtaTestVisualizer.java
+++ b/subprojects/xta/xta-testgen/src/main/java/hu/bme/mit/theta/xta/testgen/XtaTestVisualizer.java
@@ -1,0 +1,80 @@
+package hu.bme.mit.theta.xta.testgen;
+
+import hu.bme.mit.theta.analysis.algorithm.ArgNode;
+import hu.bme.mit.theta.analysis.algorithm.ArgTrace;
+import hu.bme.mit.theta.common.visualization.EdgeAttributes;
+import hu.bme.mit.theta.common.visualization.Graph;
+import hu.bme.mit.theta.common.visualization.LineStyle;
+import hu.bme.mit.theta.common.visualization.NodeAttributes;
+import hu.bme.mit.theta.common.visualization.Shape;
+import hu.bme.mit.theta.common.visualization.writer.GraphvizWriter;
+import hu.bme.mit.theta.xta.XtaProcess;
+import hu.bme.mit.theta.xta.analysis.XtaState;
+
+import java.awt.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class XtaTestVisualizer {
+	public static void visualizeTests(Set<? extends XtaTest<?, ?>> tests) {
+		for (XtaTest<?, ?> test : tests)
+			visualizeTest(test);
+	}
+
+	public static void visualizeTest(XtaTest<?, ?> test) {
+		Graph traceGraph = new Graph(test.getName(), String.format("%s%nTotal time: %f", test.getName(), test.getTotalTime()));
+
+		Map<Integer, XtaProcess.Loc> indexLocMap = new HashMap<>();
+		Map<Integer, String> indexIdMap = new HashMap<>();
+
+		ArgTrace<? extends XtaState<?>, ?> trace = test.getTrace();
+		for (int i = 0; i < trace.nodes().size(); i++) {
+			ArgNode<? extends XtaState<?>, ?> n = trace.nodes().get(i);
+			XtaState<?> st = n.getState();
+
+			List<XtaProcess.Loc> locs = st.getLocs();
+
+			for (int j = 0; j < locs.size(); j++) {
+				XtaProcess.Loc l = locs.get(j);
+				String id = String.format("%s__%d", l.getName(), i);
+				String label = String.format("%s%ndelay: %f", id, test.getDelays().get(i));
+
+				NodeAttributes nAttributes = NodeAttributes.builder().label(label).fillColor(Color.WHITE)
+						.lineColor(Color.BLACK).lineStyle(LineStyle.NORMAL).peripheries(1).build();
+
+				NodeAttributes invisibleAttributes = NodeAttributes.builder().label(id).fillColor(Color.WHITE)
+						.lineColor(Color.BLACK).lineStyle(LineStyle.NORMAL).peripheries(1).invisible(true).build();
+
+				EdgeAttributes eAttributes = EdgeAttributes.builder()
+						.color(Color.BLACK).lineStyle(LineStyle.NORMAL).build();
+
+				if (i == 0) {
+					NodeAttributes startAttributes = NodeAttributes.builder().fillColor(Color.BLACK)
+							.lineColor(Color.BLACK).lineStyle(LineStyle.NORMAL).peripheries(1).shape(Shape.RECTANGLE).build();
+					String startId = "start__" + id;
+					traceGraph.addNode(startId, startAttributes);
+					traceGraph.addNode(id, nAttributes);
+					traceGraph.addEdge(startId, id, eAttributes);
+				} else {
+					String prevId = indexIdMap.get(j);
+					if (!indexLocMap.containsValue(l)) {
+						traceGraph.addNode(id, nAttributes);
+					} else {
+						traceGraph.addNode(id, invisibleAttributes);
+					}
+					traceGraph.addEdge(prevId, id, eAttributes);
+				}
+				indexLocMap.put(j, l);
+				indexIdMap.put(j, id);
+			}
+		}
+
+		try {
+			GraphvizWriter.getInstance().writeFile(traceGraph, traceGraph.getId() + ".png", GraphvizWriter.Format.PNG);
+		} catch (Exception  e) {
+			e.printStackTrace();
+		}
+	}
+}


### PR DESCRIPTION
Location-covering test generation for XTA models, developed in my BSc thesis.
* New subproject that contains test-generation related functionalities
* XtaAction.DELAY variable is now public (because we need to refer to that in other places)
* GraphvizWriter (and NodeAttributes) supports invisible nodes
* Command line arguments to turn on test generation and visualization