### PR TITLE
Add Windows build to CI, disable float tests on Windows.

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -3,7 +3,7 @@ name: Build Theta with Gradle
 on: [push, pull_request]
 
 jobs:
-  build:
+  build-ubuntu:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -19,3 +19,13 @@ jobs:
       run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report
       env:
         CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+  build-win:
+    runs-on: windows-2019
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.11
+    - name: Build with Gradle
+      run: .\gradlew.bat build

--- a/doc/Build.md
+++ b/doc/Build.md
@@ -2,7 +2,8 @@
 
 Theta uses Java (JDK) 11 with [Gradle 6](https://gradle.org/) as a build system.
 Currently, we use [OpenJDK 11](https://openjdk.java.net/projects/jdk/11/) (see instructions for [Windows](https://stackoverflow.com/questions/52511778/how-to-install-openjdk-11-on-windows) and [Ubuntu](https://www.linuxuprising.com/2019/01/how-to-install-openjdk-11-in-ubuntu.html)).
-We are mainly developing on Windows, but we also test Theta on Linux.
+We are developing Theta both on Linux and Windows.
+Currently, floating point types are only supported on Linux.
 Theta can be built from the command line, but you can also import it into [IntelliJ IDEA](https://www.jetbrains.com/idea/).
 Unfortunately, Eclipse [does not support](https://github.com/eclipse/buildship/issues/222) Gradle projects with Kotlin build scripts (yet).
 

--- a/doc/Development.md
+++ b/doc/Development.md
@@ -3,7 +3,7 @@
 Theta is written in Java 11 using
 * [Gradle](https://gradle.org/) as a build system,
 * [Git](https://git-scm.com/) and [GitHub](https://github.com/FTSRG/theta) for version control,
-* [Travis](https://travis-ci.org/FTSRG/theta) and [GitHub actions](https://github.com/ftsrg/theta/actions) for continuous integration,
+* [GitHub actions](https://github.com/ftsrg/theta/actions) for continuous integration,
 * [Codacy](https://www.codacy.com/app/FTSRG/theta/dashboard) for static code analysis,
 * [Docker](https://www.docker.com/) for packaging.
 

--- a/subprojects/cfa/cfa/README.md
+++ b/subprojects/cfa/cfa/README.md
@@ -39,7 +39,7 @@ Variables of the CFA can have the following types.
 * `rat`: Rational numbers (implemented as SMT reals).
 * `[K] -> V`: SMT arrays (associative maps) from a given key type `K` to a value type `V`.
 * `bv[L]`: Bitvector of given length `L`. _This is an experimental feature. See the [details](doc/bitvectors.md) for more information._
-* `fp[E:S]`: Floating point of given size exponent `E` and significand `S`. Significand size should include the hidden bit as well. The type corresponds to the FloatingPoint type in the [SMT-LIB theory](https://smtlib.cs.uiowa.edu/theories-FloatingPoint.shtml)
+* `fp[E:S]`: Floating point of given size exponent `E` and significand `S`. Significand size should include the hidden bit as well. The type corresponds to the FloatingPoint type in the [SMT-LIB theory](https://smtlib.cs.uiowa.edu/theories-FloatingPoint.shtml). _Note that this feature currently only works on Linux due to the required MPFR library._
 
 Expressions of the CFA include the following.
 * Identifiers (variables).

--- a/subprojects/common/core/src/test/java/hu/bme/mit/theta/core/type/FpTypeTest.java
+++ b/subprojects/common/core/src/test/java/hu/bme/mit/theta/core/type/FpTypeTest.java
@@ -1,5 +1,7 @@
 package hu.bme.mit.theta.core.type;
 
+import com.google.common.collect.ImmutableSet;
+import hu.bme.mit.theta.common.OsHelper;
 import hu.bme.mit.theta.core.model.ImmutableValuation;
 import hu.bme.mit.theta.core.model.Valuation;
 import hu.bme.mit.theta.core.type.fptype.FpLeqExpr;
@@ -39,6 +41,7 @@ public class FpTypeTest {
 
 	@Parameterized.Parameters(name = "expr: {0}, expected: {1}, actual: {2}")
 	public static Collection<?> operations() {
+		if (OsHelper.getOs().equals(OsHelper.OperatingSystem.WINDOWS)) return ImmutableSet.of();
 		return Stream.concat(
 				FpTestUtils.BasicOperations().stream(),
 				Stream.concat(

--- a/subprojects/common/solver-z3/src/test/java/hu/bme/mit/theta/solver/z3/Z3SolverFPTest.java
+++ b/subprojects/common/solver-z3/src/test/java/hu/bme/mit/theta/solver/z3/Z3SolverFPTest.java
@@ -11,8 +11,6 @@ import hu.bme.mit.theta.core.utils.FpTestUtils;
 import hu.bme.mit.theta.core.utils.FpUtils;
 import hu.bme.mit.theta.solver.Solver;
 import hu.bme.mit.theta.solver.SolverStatus;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;

--- a/subprojects/common/solver-z3/src/test/java/hu/bme/mit/theta/solver/z3/Z3SolverFPTest.java
+++ b/subprojects/common/solver-z3/src/test/java/hu/bme/mit/theta/solver/z3/Z3SolverFPTest.java
@@ -1,5 +1,7 @@
 package hu.bme.mit.theta.solver.z3;
 
+import com.google.common.collect.ImmutableSet;
+import hu.bme.mit.theta.common.OsHelper;
 import hu.bme.mit.theta.core.type.Expr;
 import hu.bme.mit.theta.core.type.abstracttype.EqExpr;
 import hu.bme.mit.theta.core.type.fptype.FpLeqExpr;
@@ -9,6 +11,8 @@ import hu.bme.mit.theta.core.utils.FpTestUtils;
 import hu.bme.mit.theta.core.utils.FpUtils;
 import hu.bme.mit.theta.solver.Solver;
 import hu.bme.mit.theta.solver.SolverStatus;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -41,6 +45,7 @@ public class Z3SolverFPTest {
 
 	@Parameters(name = "expr: {0}, expected: {1}, actual: {2}")
 	public static Collection<?> operations() {
+		if (OsHelper.getOs().equals(OsHelper.OperatingSystem.WINDOWS)) return ImmutableSet.of();
 		return Stream.concat(
 				FpTestUtils.BasicOperations().stream(),
 				Stream.concat(


### PR DESCRIPTION
This PR adds a basic Windows build to CI (GitHub actions). Currently it's failing due to a missing library for floats:
```
java.lang.UnsatisfiedLinkError at Z3SolverFPTest.java:45
```

But if we fix that and rebase this PR, I think it should work. But let's wait for that fix first.