### PR TITLE
Update jacoco workflow

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -20,6 +20,6 @@ jobs:
     - name: Build with Gradle
       run: ./gradlew build
     - name: Send test coverage to Codacy
-      run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -l Java $(find **/jacoco*.xml -printf '-r %p ')
+      run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -l Java $(find '**/jacoco*.xml' -printf '-r %p ')
       env:
         CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}


### PR DESCRIPTION
Bash tries to understand `**/jacoco*.xml`, but find is the one who will parse the asterisks.

It leads to a ambigious error message `**/jacoco*.xml not found`