### PR TITLE
Added Github Actions task for copyright checking 

### DIFF
--- a/.github/workflows/check-copyright.yml
+++ b/.github/workflows/check-copyright.yml
@@ -1,0 +1,18 @@
+name: Copyright check
+
+on: [pull_request]
+
+jobs:
+  check-copyright:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Check copyright header in every .java and .kt file
+      run: |
+        LIST=$(find . -type f \( -name "*.java" -o -name "*.kt" \) -exec grep -HL 'Copyright 20.. Budapest University of Technology and Economics' '{}' ';')
+        [ -z "$LIST" ] && echo "Copyright OK" || printf "Copyright notice not present in files:\n$LIST\n"
+        [ -z "$LIST" ]

--- a/.github/workflows/check-copyright.yml
+++ b/.github/workflows/check-copyright.yml
@@ -1,6 +1,9 @@
 name: Copyright check
 
-on: [pull_request]
+on:
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   check-copyright:


### PR DESCRIPTION
This PR adds a new GH Action which checks pull requests for the presence of a copyright header in each java and kotlin file. Moving forward, this should be mandatory for all PRs before merge.  