### PR TITLE
Fix windows build

### DIFF
--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -15,11 +15,12 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.11
-    - name: Build with Gradle
+    - name: Install VC-Redist 2012
       run: |
         Install-Module -Name VcRedist -Force
-        New-Item -Path C:\Temp\VcRedist -ItemType Directory
+        New-Item -ItemType Directory
         $VcList = Get-VcList -Release "2012"
-        Save-VcRedist -VcList $VcList -Path C:\Temp\VcRedist
-        Install-VcRedist -Path C:\Temp\VcRedist -VcList $VcList -Silent
-        .\gradlew.bat build
+        Save-VcRedist -VcList $VcList
+        Install-VcRedist -VcList $VcList -Silent
+    - name: Build with Gradle
+      run: .\gradlew.bat build

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install VC-Redist 2012
       run: |
         Install-Module -Name VcRedist -Force
-        $VcList = Get-VcList -Release "2012"
+        $VcList = Get-VcList -Export All | Where-Object { $_.Release -eq "2010" -or $_.Release -eq "2012" }
         Save-VcRedist -VcList $VcList
         Install-VcRedist -VcList $VcList -Silent
     - name: Build with Gradle

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.11
-    - name: Install VC-Redist 2012
+    - name: Install VC-Redist 2010 and 2012
       run: |
         Install-Module -Name VcRedist -Force
         $VcList = Get-VcList -Export All | Where-Object { $_.Release -eq "2010" -or $_.Release -eq "2012" }

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -16,4 +16,10 @@ jobs:
       with:
         java-version: 1.11
     - name: Build with Gradle
-      run: .\gradlew.bat build
+      run: |
+        Install-Module -Name VcRedist -Force
+        New-Item -Path C:\Temp\VcRedist -ItemType Directory
+        $VcList = Get-VcList -Release "2012"
+        Save-VcRedist -VcList $VcList -Path C:\Temp\VcRedist
+        Install-VcRedist -Path C:\Temp\VcRedist -VcList $VcList -Silent
+        .\gradlew.bat build

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -18,7 +18,6 @@ jobs:
     - name: Install VC-Redist 2012
       run: |
         Install-Module -Name VcRedist -Force
-        New-Item -ItemType Directory
         $VcList = Get-VcList -Release "2012"
         Save-VcRedist -VcList $VcList
         Install-VcRedist -VcList $VcList -Silent


### PR DESCRIPTION
This PR solves the build error in the windows Github Actions. It installs the 2010 and 2012 VC++ redistributables before attempting to compile Theta.  