### PR TITLE
Javadoc should only be deployed when pushing to master

### DIFF
--- a/.github/workflows/deploy-javadoc.yml
+++ b/.github/workflows/deploy-javadoc.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Generate Javadoc
         run: ./gradlew aggregateJavadoc
       - name: Deploy Javadoc
+        if: github.ref == 'refs/heads/master'
         uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           branch: gh-pages


### PR DESCRIPTION
This PR enables the javadoc action to check commits on all branches, but only the ones pushed to master will be deployed.