### PR TITLE
Disabled windows-2016 check, added windows-2022

### DIFF
--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, windows-2019, windows-2016]
+        os: [windows-latest, windows-2019, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Can we safely discard the windows-2016 check? It seems to get cancelled on its own for the last few commits.