### PR TITLE
Java 17 doc fix

### DIFF
--- a/doc/Build.md
+++ b/doc/Build.md
@@ -1,6 +1,6 @@
 # Building Theta
 
-Theta uses Java (JDK) 17 with [Gradle 6](https://gradle.org/) as a build system.
+Theta uses Java (JDK) 17 with [Gradle 7.4](https://gradle.org/) as a build system.
 Currently, we use [OpenJDK 17](https://openjdk.java.net/projects/jdk/17/) (see instructions for [Windows](https://java.tutorials24x7.com/blog/how-to-install-openjdk-17-on-windows) and [Ubuntu](https://www.linuxuprising.com/2019/04/install-latest-openjdk-12-11-or-8-in.html)).
 We are developing Theta both on Linux and Windows.
 Currently, floating point types are only fully supported on Linux. Windows support is experimental and can cause cryptic exceptions to occur in native code. 

--- a/doc/Build.md
+++ b/doc/Build.md
@@ -1,7 +1,7 @@
 # Building Theta
 
-Theta uses Java (JDK) 11 with [Gradle 6](https://gradle.org/) as a build system.
-Currently, we use [OpenJDK 11](https://openjdk.java.net/projects/jdk/11/) (see instructions for [Windows](https://stackoverflow.com/questions/52511778/how-to-install-openjdk-11-on-windows) and [Ubuntu](https://www.linuxuprising.com/2019/01/how-to-install-openjdk-11-in-ubuntu.html)).
+Theta uses Java (JDK) 17 with [Gradle 6](https://gradle.org/) as a build system.
+Currently, we use [OpenJDK 17](https://openjdk.java.net/projects/jdk/17/) (see instructions for [Windows](https://java.tutorials24x7.com/blog/how-to-install-openjdk-17-on-windows) and [Ubuntu](https://www.linuxuprising.com/2019/04/install-latest-openjdk-12-11-or-8-in.html)).
 We are developing Theta both on Linux and Windows.
 Currently, floating point types are only fully supported on Linux. Windows support is experimental and can cause cryptic exceptions to occur in native code. 
 Theta can be built from the command line, but you can also import it into [IntelliJ IDEA](https://www.jetbrains.com/idea/).

--- a/doc/Development.md
+++ b/doc/Development.md
@@ -1,6 +1,6 @@
 # Development guide
 
-Theta is written in Java 11 using
+Theta is written in Java 17 using
 * [Gradle](https://gradle.org/) as a build system,
 * [Git](https://git-scm.com/) and [GitHub](https://github.com/FTSRG/theta) for version control,
 * [GitHub actions](https://github.com/ftsrg/theta/actions) for continuous integration,

--- a/subprojects/cfa/cfa-cli/README.md
+++ b/subprojects/cfa/cfa-cli/README.md
@@ -20,7 +20,7 @@ For more information about the CFA formalism and its supported language elements
     * The easiest way is to download a [pre-built release](https://github.com/ftsrg/theta/releases).
     * You can also [build](../../../doc/Build.md) the tool yourself. The runnable jar file will appear under _build/libs/_ with the name _theta-cfa-cli-\<VERSION\>-all.jar_, you can simply rename it to _theta-cfa-cli.jar_.
     * Alternatively, you can use our docker image (see below).
-2. Running the tool requires Java (JRE) 11.
+2. Running the tool requires Java (JRE) 17.
 3. The tool also requires the [Z3 SMT solver libraries](../../../doc/Build.md) to be available on `PATH`.
 4. The tool can be executed with `java -jar theta-cfa-cli.jar [ARGUMENTS]`.
     * If no arguments are given, a help screen is displayed about the arguments and their possible values.

--- a/subprojects/solver/solver-smtlib-cli/README.md
+++ b/subprojects/solver/solver-smtlib-cli/README.md
@@ -15,7 +15,7 @@ For more information about the SMT-LIB compatibility in Theta, take a look at th
 1. First, get the tool.
     * The easiest way is to download a [pre-built release](https://github.com/ftsrg/theta/releases).
     * You can also [build](../../../doc/Build.md) the tool yourself. The runnable jar file will appear under _build/libs/_ with the name _theta-solver-smtlib-cli-\<VERSION\>-all.jar_, you can simply rename it to _theta-solver-smtlib-cli.jar_..
-2. Running the tool requires Java (JRE) 11.
+2. Running the tool requires Java (JRE) 17.
 3. The tool can be executed with `java -jar theta-solver-smtlib-cli.jar [MAIN ARGUMENTS] [COMMAND] [ARGUMENTS]`.
     * If no arguments are given, a help screen is displayed about the arguments and their possible values.
     More information can also be found below.

--- a/subprojects/sts/sts-cli/README.md
+++ b/subprojects/sts/sts-cli/README.md
@@ -14,7 +14,7 @@ For more information about the STS formalism and its supported language elements
     * The easiest way is to download a [pre-built release](https://github.com/ftsrg/theta/releases).
     * You can also [build](../../../doc/Build.md) the tool yourself. The runnable jar file will appear under _build/libs/_ with the name _theta-sts-cli-\<VERSION\>-all.jar_, you can simply rename it to _theta-sts-cli.jar_.
     * Alternatively, you can use our docker image (see below).
-2. Running the tool requires Java (JRE) 11.
+2. Running the tool requires Java (JRE) 17.
 3. The tool also requires the [Z3 SMT solver libraries](../../../doc/Build.md) to be available on `PATH`.
 4. The tool can be executed with `java -jar theta-sts-cli.jar [ARGUMENTS]`.
     * If no arguments are given, a help screen is displayed about the arguments and their possible values.

--- a/subprojects/xsts/xsts-cli/README.md
+++ b/subprojects/xsts/xsts-cli/README.md
@@ -17,7 +17,7 @@ For more information about the XSTS formalism and its supported language element
     * The easiest way is to download a [pre-built release](https://github.com/ftsrg/theta/releases).
     * You can also [build](../../../doc/Build.md) the tool yourself. The runnable jar file will appear under _build/libs/_ with the name _theta-xsts-cli-\<VERSION\>-all.jar_, you can simply rename it to _theta-xsts-cli.jar_.
     * Alternatively, you can use our docker image (see below).
-2. Running the tool requires Java (JRE) 11.
+2. Running the tool requires Java (JRE) 17.
 3. The tool also requires the [Z3 SMT solver libraries](../../../doc/Build.md) to be available on `PATH`.
 4. The tool can be executed with `java -jar theta-xsts-cli.jar [ARGUMENTS]`.
     * If no arguments are given, a help screen is displayed about the arguments and their possible values.

--- a/subprojects/xta/xta-cli/README.md
+++ b/subprojects/xta/xta-cli/README.md
@@ -13,7 +13,7 @@ This project contains an executable tool (command line) for running analyses on 
     * The easiest way is to download a [pre-built release](https://github.com/ftsrg/theta/releases).
     * You can also [build](../../../doc/Build.md) the tool yourself. The runnable jar file will appear under _build/libs/_ with the name _theta-xta-cli-\<VERSION\>-all.jar_, you can simply rename it to _theta-xta-cli.jar_.
     * Alternatively, you can use our docker image (see below).
-2. Running the tool requires Java (JRE) 11.
+2. Running the tool requires Java (JRE) 17.
 3. The tool also requires the [Z3 SMT solver libraries](../../../doc/Build.md) to be available on `PATH`.
 4. The tool can be executed with `java -jar theta-xta-cli.jar [ARGUMENTS]`.
     * If no arguments are given, a help screen is displayed about the arguments and their possible values.


### PR DESCRIPTION
Currently, theta uses Java 17, but no documentation has been up-to-date about this. This PR aims to fix this shortcoming.