### PR TITLE
Adding no refinement progress detection to XSTS cli

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ buildscript {
 
 allprojects {
     group = "hu.bme.mit.inf.theta"
-    version = "4.2.1"
+    version = "4.2.2"
 
     apply(from = rootDir.resolve("gradle/shared-with-buildSrc/mirrors.gradle.kts"))
 }

--- a/subprojects/xsts/xsts-analysis/src/main/java/hu/bme/mit/theta/xsts/analysis/XstsState.java
+++ b/subprojects/xsts/xsts-analysis/src/main/java/hu/bme/mit/theta/xsts/analysis/XstsState.java
@@ -5,6 +5,8 @@ import hu.bme.mit.theta.common.Utils;
 import hu.bme.mit.theta.core.type.Expr;
 import hu.bme.mit.theta.core.type.booltype.BoolType;
 
+import java.util.Objects;
+
 public final class XstsState<S extends ExprState> implements ExprState {
 
 	private final S state;
@@ -46,5 +48,18 @@ public final class XstsState<S extends ExprState> implements ExprState {
 	@Override
 	public String toString() {
 		return Utils.lispStringBuilder(getClass().getSimpleName()).aligned().add(initialized ? "post_init" : "pre_init").add(lastActionWasEnv ? "last_env" : "last_internal").body().add(state).toString();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		XstsState<?> xstsState = (XstsState<?>) o;
+		return lastActionWasEnv == xstsState.lastActionWasEnv && initialized == xstsState.initialized && state.equals(xstsState.state);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(state, lastActionWasEnv, initialized);
 	}
 }

--- a/subprojects/xsts/xsts-cli/src/main/java/hu/bme/mit/theta/xsts/cli/XstsCli.java
+++ b/subprojects/xsts/xsts-cli/src/main/java/hu/bme/mit/theta/xsts/cli/XstsCli.java
@@ -7,6 +7,7 @@ import com.google.common.base.Stopwatch;
 import hu.bme.mit.theta.analysis.Trace;
 import hu.bme.mit.theta.analysis.algorithm.SafetyResult;
 import hu.bme.mit.theta.analysis.algorithm.cegar.CegarStatistics;
+import hu.bme.mit.theta.analysis.algorithm.runtimecheck.ArgCexCheckHandler;
 import hu.bme.mit.theta.analysis.expr.refinement.PruneStrategy;
 import hu.bme.mit.theta.analysis.utils.ArgVisualizer;
 import hu.bme.mit.theta.analysis.utils.TraceVisualizer;
@@ -101,6 +102,9 @@ public class XstsCli {
 
 	@Parameter(names = {"--visualize"}, description = "Write proof or counterexample to file in dot format")
 	String dotfile = null;
+
+	@Parameter(names = "--stop-if-stuck")
+	boolean stopIfStuck = false;
 
 	private Logger logger;
 
@@ -199,6 +203,13 @@ public class XstsCli {
 	}
 
 	private XstsConfig<?, ?, ?> buildConfiguration(final XSTS xsts) throws Exception {
+		// set up stopping analysis if it is stuck on same ARGs and precisions
+		if (!stopIfStuck) {
+			ArgCexCheckHandler.instance.setArgCexCheck(false, false);
+		} else {
+			ArgCexCheckHandler.instance.setArgCexCheck(true, refinement.equals(Refinement.MULTI_SEQ));
+		}
+
 		try {
 			return new XstsConfigBuilder(domain, refinement, Z3SolverFactory.getInstance())
 					.maxEnum(maxEnum).autoExpl(autoExpl).initPrec(initPrec).pruneStrategy(pruneStrategy)

--- a/subprojects/xsts/xsts-cli/src/main/java/hu/bme/mit/theta/xsts/cli/XstsCli.java
+++ b/subprojects/xsts/xsts-cli/src/main/java/hu/bme/mit/theta/xsts/cli/XstsCli.java
@@ -103,8 +103,8 @@ public class XstsCli {
 	@Parameter(names = {"--visualize"}, description = "Write proof or counterexample to file in dot format")
 	String dotfile = null;
 
-	@Parameter(names = "--stop-if-stuck")
-	boolean stopIfStuck = false;
+	@Parameter(names = "--no-stuck-check")
+	boolean noStuckCheck = false;
 
 	private Logger logger;
 
@@ -204,7 +204,7 @@ public class XstsCli {
 
 	private XstsConfig<?, ?, ?> buildConfiguration(final XSTS xsts) throws Exception {
 		// set up stopping analysis if it is stuck on same ARGs and precisions
-		if (!stopIfStuck) {
+		if (noStuckCheck) {
 			ArgCexCheckHandler.instance.setArgCexCheck(false, false);
 		} else {
 			ArgCexCheckHandler.instance.setArgCexCheck(true, refinement.equals(Refinement.MULTI_SEQ));


### PR DESCRIPTION
This patch adds the (already existing) functionality of stopping the analysis if there is no refinement progress to XSTS cli.
(It is merely the addition of a new flag, this feature was already in use with XCFAs.)

The check is ON by default (same as with XCFAs). It can be turned off using the `--no-stuck-check` flag.
If there is no refinement progress and the analysis is constantly rebuilding the same ARGs, it stops the analysis and throws a `NotSolvableException`.

As it is basically a runtime monitoring method, it poses a minimal overhead, but it is barely noticeable, if noticeable at all. None the less, the option to turn it off is there if it is needed, e.g. for debugging.

The monitoring is implemented a bit differently in the case of MULTI_SEQ refinement, but I could not test that with an XSTS model, as I do not know about any XSTS that gets stuck with MULTI_SEQ. (But it works with XCFAs, so I see no reason for issues with XSTS.)

@grbeni I added you as a reviewer, so you know about the new flag and exception