### PR TITLE
Fixed copy-paste error in hash code functions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ buildscript {
 
 allprojects {
     group = "hu.bme.mit.inf.theta"
-    version = "4.2.2"
+    version = "4.2.3"
 
     apply(from = rootDir.resolve("gradle/shared-with-buildSrc/mirrors.gradle.kts"))
 }

--- a/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/prod2/Prod2Prec.java
+++ b/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/prod2/Prod2Prec.java
@@ -56,7 +56,7 @@ public final class Prod2Prec<P1 extends Prec, P2 extends Prec> implements Prec {
 			result = HASH_SEED;
 			result = 37 * result + prec1.hashCode();
 			result = 37 * result + prec2.hashCode();
-			result = hashCode;
+            hashCode = result;
 		}
 		return result;
 	}

--- a/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/prod2/Prod2State.java
+++ b/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/prod2/Prod2State.java
@@ -157,7 +157,7 @@ public abstract class Prod2State<S1 extends State, S2 extends State> implements 
 				result = HASH_SEED;
 				result = 37 * result + state1.hashCode();
 				result = 37 * result + state2.hashCode();
-				result = hashCode;
+                hashCode = result;
 			}
 			return result;
 		}
@@ -214,7 +214,7 @@ public abstract class Prod2State<S1 extends State, S2 extends State> implements 
 				result = HASH_SEED;
 				result = 37 * result + getIndex();
 				result = 37 * result + getState().hashCode();
-				result = hashCode;
+                hashCode = result;
 			}
 			return result;
 		}

--- a/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/prod3/Prod3Prec.java
+++ b/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/prod3/Prod3Prec.java
@@ -64,7 +64,7 @@ public final class Prod3Prec<P1 extends Prec, P2 extends Prec, P3 extends Prec> 
 			result = 37 * result + prec1.hashCode();
 			result = 37 * result + prec2.hashCode();
 			result = 37 * result + prec3.hashCode();
-			result = hashCode;
+            hashCode = result;
 		}
 		return result;
 	}

--- a/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/prod3/Prod3State.java
+++ b/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/prod3/Prod3State.java
@@ -204,7 +204,7 @@ public abstract class Prod3State<S1 extends State, S2 extends State, S3 extends 
 				result = 37 * result + state1.hashCode();
 				result = 37 * result + state2.hashCode();
 				result = 37 * result + state3.hashCode();
-				result = hashCode;
+                hashCode = result;
 			}
 			return result;
 		}
@@ -264,7 +264,7 @@ public abstract class Prod3State<S1 extends State, S2 extends State, S3 extends 
 				result = HASH_SEED;
 				result = 37 * result + getIndex();
 				result = 37 * result + getState().hashCode();
-				result = hashCode;
+                hashCode = result;
 			}
 			return result;
 		}

--- a/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/prod4/Prod4Prec.java
+++ b/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/prod4/Prod4Prec.java
@@ -71,7 +71,7 @@ public final class Prod4Prec<P1 extends Prec, P2 extends Prec, P3 extends Prec, 
 			result = 37 * result + prec2.hashCode();
 			result = 37 * result + prec3.hashCode();
 			result = 37 * result + prec4.hashCode();
-			result = hashCode;
+            hashCode = result;
 		}
 		return result;
 	}

--- a/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/prod4/Prod4State.java
+++ b/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/prod4/Prod4State.java
@@ -246,7 +246,7 @@ public abstract class Prod4State<S1 extends State, S2 extends State, S3 extends 
 				result = 37 * result + state2.hashCode();
 				result = 37 * result + state3.hashCode();
 				result = 37 * result + state4.hashCode();
-				result = hashCode;
+                hashCode = result;
 			}
 			return result;
 		}
@@ -306,7 +306,7 @@ public abstract class Prod4State<S1 extends State, S2 extends State, S3 extends 
 				result = HASH_SEED;
 				result = 37 * result + getIndex();
 				result = 37 * result + getState().hashCode();
-				result = hashCode;
+                hashCode = result;
 			}
 			return result;
 		}

--- a/subprojects/common/core/src/main/java/hu/bme/mit/theta/core/type/UnaryExpr.java
+++ b/subprojects/common/core/src/main/java/hu/bme/mit/theta/core/type/UnaryExpr.java
@@ -64,7 +64,7 @@ public abstract class UnaryExpr<OpType extends Type, ExprType extends Type> impl
 		if (result == 0) {
 			result = getHashSeed();
 			result = 37 * result + getOp().hashCode();
-			result = hashCode;
+            hashCode = result;
 		}
 		return result;
 	}

--- a/subprojects/xta/xta-analysis/src/main/java/hu/bme/mit/theta/xta/analysis/expl/itp/ItpExplState.java
+++ b/subprojects/xta/xta-analysis/src/main/java/hu/bme/mit/theta/xta/analysis/expl/itp/ItpExplState.java
@@ -78,7 +78,7 @@ public final class ItpExplState implements ExprState {
 			result = HASH_SEED;
 			result = 37 * result + concrState.hashCode();
 			result = 37 * result + abstrState.hashCode();
-			result = hashCode;
+            hashCode = result;
 		}
 		return result;
 	}

--- a/subprojects/xta/xta-analysis/src/main/java/hu/bme/mit/theta/xta/analysis/zone/itp/ItpZoneState.java
+++ b/subprojects/xta/xta-analysis/src/main/java/hu/bme/mit/theta/xta/analysis/zone/itp/ItpZoneState.java
@@ -92,7 +92,7 @@ public final class ItpZoneState implements ExprState {
 			result = HASH_SEED;
 			result = 37 * result + concrState.hashCode();
 			result = 37 * result + abstrState.hashCode();
-			result = hashCode;
+            hashCode = result;
 		}
 		return result;
 	}


### PR DESCRIPTION
The last line of hash calculations (`hashCode = result`) was reversed in several States/Expressions resulting in incorrect hash codes.
It seems like I'm the first one to heavily lean on hash codes of states, as no one noticed it before.
It was like this more or less since the beginning of Theta and it was probably propagated by copying and pasting these calculations. I hope I found all of them.