### PR TITLE
Added maven publishing to gradle

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ buildscript {
 }
 
 allprojects {
-    group = "hu.bme.mit.inf.theta"
+    group = "hu.bme.mit.theta"
     version = "4.2.3"
 
     apply(from = rootDir.resolve("gradle/shared-with-buildSrc/mirrors.gradle.kts"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     base
     id("jacoco-common")
     id("io.freefair.aggregate-javadoc") version "5.2"
+    id("io.codearte.nexus-staging") version "0.30.0" apply true
 }
 
 buildscript {
@@ -11,7 +12,7 @@ buildscript {
 
 allprojects {
     group = "hu.bme.mit.theta"
-    version = "4.2.3"
+    version = "4.2.4"
 
     apply(from = rootDir.resolve("gradle/shared-with-buildSrc/mirrors.gradle.kts"))
 }
@@ -50,5 +51,11 @@ tasks {
 
     check {
         dependsOn(test)
+    }
+
+    nexusStaging {
+        serverUrl = "https://s01.oss.sonatype.org/service/local/"
+        username = System.getenv("OSSRH_USERNAME")
+        password = System.getenv("OSSRH_PASSWORD")
     }
 }

--- a/buildSrc/src/main/kotlin/java-common.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-common.gradle.kts
@@ -1,5 +1,6 @@
 apply<JavaPlugin>()
 apply(plugin = "jacoco-common")
+apply(plugin = "maven-artifact")
 
 dependencies {
     val implementation: Configuration by configurations

--- a/buildSrc/src/main/kotlin/maven-artifact.gradle.kts
+++ b/buildSrc/src/main/kotlin/maven-artifact.gradle.kts
@@ -1,0 +1,90 @@
+plugins {
+    `java-library`
+    `maven-publish`
+    signing
+}
+
+
+open class MavenArtifactExtension(project: Project) {
+    var artifactId: String = project.name
+    var name: String = project.name.split("-").joinToString(" ", transform = String::capitalize)
+    var description: String = project.name.split("-").let{ it.subList(1, it.size).joinToString(" ", transform = String::capitalize) } + " subproject in the Theta model checking framework"
+    var url: String = "https://theta.mit.bme.hu/"
+    var licenseName: String = "The Apache License, Version 2.0"
+    var licenseUrl: String = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+    var connection: String = "scm:git:git://github.com/ftsrg/theta.git"
+    var developerConnection: String = "scm:git:ssh://github.com:ftsrg/theta.git"
+}
+
+val artifactConfig = extensions.create<MavenArtifactExtension>("maven-artifact", project)
+
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
+tasks {
+    publishing {
+        publications {
+            create<MavenPublication>("mavenJava") {
+                artifactId = artifactConfig.artifactId
+                from(components["java"])
+                versionMapping {
+                    usage("java-api") {
+                        fromResolutionOf("runtimeClasspath")
+                    }
+                    usage("java-runtime") {
+                        fromResolutionResult()
+                    }
+                }
+                pom {
+                    name.set(artifactConfig.name)
+                    description.set(artifactConfig.description)
+                    url.set(artifactConfig.url)
+                    licenses {
+                        license {
+                            name.set(artifactConfig.licenseName)
+                            url.set(artifactConfig.licenseUrl)
+                        }
+                    }
+                    developers {
+                        val contribFile = project.rootProject.rootDir.toPath().resolve("CONTRIBUTORS.md").toFile()
+                        if (contribFile.exists()) {
+                            contribFile.readLines().forEach { line ->
+                                "\\* \\[(.*)]\\((.*)\\)".toRegex().matchEntire(line)?.let { matchResult ->
+                                    val (parsedName, parsedUrl) = matchResult.destructured
+                                    developer {
+                                        name.set(parsedName)
+                                        url.set(parsedUrl)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    scm {
+                        connection.set(artifactConfig.connection)
+                        developerConnection.set(artifactConfig.developerConnection)
+                        url.set(artifactConfig.url)
+                    }
+                }
+            }
+        }
+        repositories {
+            maven {
+                val releasesRepoUrl = uri("${project.gradle.gradleUserHomeDir}/.m2/releases")
+                val snapshotsRepoUrl = uri("${project.gradle.gradleUserHomeDir}/.m2/snapshots")
+                url = if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl
+                print(url)
+            }
+        }
+    }
+}
+
+signing {
+    sign(publishing.publications["mavenJava"])
+}
+
+tasks.javadoc {
+    if (JavaVersion.current().isJava9Compatible) {
+        (options as StandardJavadocDocletOptions).addBooleanOption("html5", true)
+    }
+}

--- a/buildSrc/src/main/kotlin/maven-artifact.gradle.kts
+++ b/buildSrc/src/main/kotlin/maven-artifact.gradle.kts
@@ -4,7 +4,6 @@ plugins {
     signing
 }
 
-
 open class MavenArtifactExtension(project: Project) {
     var artifactId: String = project.name
     var name: String = project.name.split("-").joinToString(" ", transform = String::capitalize)
@@ -70,16 +69,22 @@ tasks {
         }
         repositories {
             maven {
-                val releasesRepoUrl = uri("${project.gradle.gradleUserHomeDir}/.m2/releases")
-                val snapshotsRepoUrl = uri("${project.gradle.gradleUserHomeDir}/.m2/snapshots")
+                val releasesRepoUrl = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
+                val snapshotsRepoUrl = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
                 url = if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl
-                print(url)
+                credentials{
+                    username = System.getenv("OSSRH_USERNAME")
+                    password = System.getenv("OSSRH_PASSWORD")
+                }
             }
         }
     }
 }
 
 signing {
+    val key = System.getenv("PGP_KEY")
+    val pwd = System.getenv("PGP_PWD")
+    useInMemoryPgpKeys(key, pwd)
     sign(publishing.publications["mavenJava"])
 }
 


### PR DESCRIPTION
This PR adds a new internal Gradle plugin, called `maven-artifact`, which implements the workflow for (eventually) publishing to maven central.

**Right now it publishes to `$HOME/.gradle/.m2/releases`**. This needs to be changed before merge.

My main concern is the integration of this new workflow with the existing build infrastructure.

Use `./gradlew publish -Psigning.secretKeyRingFile=<keyRingFile> -Psigning.password=<pwd> -Psigning.keyId=<keyID>` to try out the publication flow using a PGP key.