### PR TITLE
No more removing ops in exprsimplifier for bvconcat

### DIFF
--- a/subprojects/common/core/src/main/java/hu/bme/mit/theta/core/utils/ExprSimplifier.java
+++ b/subprojects/common/core/src/main/java/hu/bme/mit/theta/core/utils/ExprSimplifier.java
@@ -1174,7 +1174,7 @@ public final class ExprSimplifier {
 				} else {
 					value = value.concat(litOp);
 				}
-				iterator.remove();
+//				iterator.remove();
 			} else {
 				return expr.withOps(ops);
 			}


### PR DESCRIPTION
This fixes a problem in ExprSimplfier for BvConcatExpr, which removed the operators from the collection when trying to evaluate the expression. 

For an expression `BvLitExpr ++ BvExp`, where the second operand is not BvLitExpr, the simplified version only included the second expression.