### PR TITLE
ARG equals/hashCode fix

### DIFF
--- a/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/ARG.java
+++ b/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/ARG.java
@@ -21,7 +21,6 @@ import hu.bme.mit.theta.analysis.State;
 import hu.bme.mit.theta.common.container.Containers;
 
 import java.util.Collection;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.stream.Stream;
@@ -220,19 +219,5 @@ public final class ARG<S extends State, A extends Action> {
         final Stream<ArgNode<S, A>> nodesToCalculate = getNodes().filter(ArgNode::isExpanded);
         final double mean = nodesToCalculate.mapToDouble(n -> n.getOutEdges().count()).average().orElse(0);
         return mean;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        ARG<?, ?> arg = (ARG<?, ?>) o;
-        return initialized == arg.initialized &&
-                initNodes.equals(arg.initNodes);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(initNodes, initialized, partialOrd);
     }
 }

--- a/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/ArgEdge.java
+++ b/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/ArgEdge.java
@@ -19,9 +19,6 @@ import hu.bme.mit.theta.analysis.Action;
 import hu.bme.mit.theta.analysis.State;
 
 public final class ArgEdge<S extends State, A extends Action> {
-    private static final int HASH_SEED = 3653;
-    private volatile int hashCode = 0;
-
     private final ArgNode<S, A> source;
     private final ArgNode<S, A> target;
     private final A action;

--- a/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/ArgEdge.java
+++ b/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/ArgEdge.java
@@ -18,35 +18,9 @@ package hu.bme.mit.theta.analysis.algorithm;
 import hu.bme.mit.theta.analysis.Action;
 import hu.bme.mit.theta.analysis.State;
 
-import java.util.Objects;
-
 public final class ArgEdge<S extends State, A extends Action> {
     private static final int HASH_SEED = 3653;
     private volatile int hashCode = 0;
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        ArgEdge<?, ?> argEdge = (ArgEdge<?, ?>) o;
-        return Objects.equals(source.getState(), argEdge.source.getState())
-                && Objects.equals(target, argEdge.target)
-                && Objects.equals(action.toString(), argEdge.action.toString());
-    }
-
-    @Override
-    public int hashCode() {
-        int result = hashCode;
-        if (result == 0) {
-            result = HASH_SEED;
-            result = 31 * result + source.getState().hashCode();
-            result = 31 * result + target.getState().hashCode();
-            result = 31 * result + action.toString().hashCode();
-            hashCode = result;
-        }
-        return result;
-        // return Objects.hash(source.getState(), target.getState(), action.toString());
-    }
 
     private final ArgNode<S, A> source;
     private final ArgNode<S, A> target;

--- a/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/ArgNode.java
+++ b/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/ArgNode.java
@@ -30,9 +30,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 public final class ArgNode<S extends State, A extends Action> {
 
-    private static final int HASH_SEED = 8543;
-    private volatile int hashCode = 0;
-
     final ARG<S, A> arg;
 
     private final int id;

--- a/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/ArgNode.java
+++ b/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/ArgNode.java
@@ -20,7 +20,9 @@ import hu.bme.mit.theta.analysis.State;
 import hu.bme.mit.theta.common.Utils;
 import hu.bme.mit.theta.common.container.Containers;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -269,29 +271,6 @@ public final class ArgNode<S extends State, A extends Action> {
     }
 
     ////
-
-    @Override
-    public int hashCode() {
-        int result = hashCode;
-        if (result == 0) {
-            result = HASH_SEED;
-            result = 31 * result + id;
-            hashCode = result;
-        }
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        ArgNode<?, ?> argNode = (ArgNode<?, ?>) o;
-        return depth == argNode.depth &&
-                state.equals(argNode.state) &&
-                coveringNode.equals(argNode.coveringNode) &&
-                Set.copyOf(outEdges).equals(Set.copyOf(argNode.outEdges)) &&
-                target == argNode.target;
-    }
 
     @Override
     public String toString() {

--- a/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/ArgStructuralEquality.java
+++ b/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/ArgStructuralEquality.java
@@ -51,6 +51,11 @@ public final class ArgStructuralEquality {
             return true;
         }
 
+        // if one is null, the two nodes are not equal
+        if (n1 == null || n2 == null) {
+            return false;
+        }
+
         // if wrapped state is not same, nodes are not equal
         if (!n1.getState().equals(n2.getState())) {
             return false;
@@ -77,6 +82,12 @@ public final class ArgStructuralEquality {
             return true;
         }
 
+        // if one is null, the two edges are not equal
+        if (e1 == null || e2 == null) {
+            return false;
+        }
+
+
         // if wrapped action is not same, edges are not equal
         if (!e1.getAction().equals(e2.getAction())) {
             return false;
@@ -96,6 +107,11 @@ public final class ArgStructuralEquality {
         // if references are the same, the two edges are equal
         if (a1 == a2) {
             return true;
+        }
+
+        // if one is null, the two args are not equal
+        if (a1 == null || a2 == null) {
+            return false;
         }
 
         Set<ArgNode<? extends State, ? extends Action>> leaves1 = a1.getNodes().filter(ArgNode::isLeaf).collect(Collectors.toUnmodifiableSet());

--- a/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/ArgStructuralEquality.java
+++ b/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/ArgStructuralEquality.java
@@ -40,24 +40,24 @@ import static com.google.common.base.Objects.equal;
 public final class ArgStructuralEquality {
     private static final Map<Object, Integer> hashCodeCache = new LinkedHashMap<>();
 
-    private ArgStructuralEquality(){
+    private ArgStructuralEquality() {
     }
 
     public static boolean equals(final ArgNode<? extends State, ? extends Action> n1,
                                  final ArgNode<? extends State, ? extends Action> n2) {
 
         // if one node has a parent but the other one does not, nodes are not equal
-        if(n1.inEdge.isPresent() != n2.inEdge.isPresent()) {
+        if (n1.inEdge.isPresent() != n2.inEdge.isPresent()) {
             return false;
         }
 
         // if in edge is not same, nodes are not equal
-        if(n1.inEdge.isPresent() && !equals(n1.inEdge.get(), n2.inEdge.get())) {
+        if (n1.inEdge.isPresent() && !equals(n1.inEdge.get(), n2.inEdge.get())) {
             return false;
         }
 
         // if wrapped state is not same, nodes are not equal
-        if(!n1.getState().equals(n2.getState())) {
+        if (!n1.getState().equals(n2.getState())) {
             return false;
         }
 
@@ -68,12 +68,12 @@ public final class ArgStructuralEquality {
                                  final ArgEdge<? extends State, ? extends Action> e2) {
 
         // if source node is not same, edges are not equal
-        if(!equals(e1.getSource(), e2.getSource())) {
+        if (!equals(e1.getSource(), e2.getSource())) {
             return false;
         }
 
         // if wrapped action is not same, edges are not equal
-        if(!e1.getAction().equals(e2.getAction())) {
+        if (!e1.getAction().equals(e2.getAction())) {
             return false;
         }
 
@@ -87,14 +87,14 @@ public final class ArgStructuralEquality {
         Set<ArgNode<? extends State, ? extends Action>> leaves2 = a2.getNodes().filter(ArgNode::isLeaf).collect(Collectors.toUnmodifiableSet());
 
         // if the two ARGs contain a different number of leaf nodes, they are not equal
-        if(leaves1.size() != leaves2.size()) {
+        if (leaves1.size() != leaves2.size()) {
             return false;
         }
 
         leaves1loop:
         for (ArgNode<? extends State, ? extends Action> n1 : leaves1) {
             for (ArgNode<? extends State, ? extends Action> n2 : leaves2) {
-                if(equals(n1, n2)) {
+                if (equals(n1, n2)) {
                     continue leaves1loop;
                 }
             }
@@ -112,10 +112,10 @@ public final class ArgStructuralEquality {
 
 
     public static int hashCode(final ArgNode<? extends State, ? extends Action> n) {
-        if(!hashCodeCache.containsKey(n)) {
+        if (!hashCodeCache.containsKey(n)) {
             int hashcode = 0;
 
-            if(n.inEdge.isPresent()) {
+            if (n.inEdge.isPresent()) {
                 hashcode += hashCode(n.inEdge.get());
             }
 
@@ -126,7 +126,7 @@ public final class ArgStructuralEquality {
     }
 
     public static int hashCode(final ArgEdge<? extends State, ? extends Action> e) {
-        if(!hashCodeCache.containsKey(e)) {
+        if (!hashCodeCache.containsKey(e)) {
             int hashcode = 0;
 
             hashcode += hashCode(e.getSource());
@@ -151,7 +151,7 @@ public final class ArgStructuralEquality {
     }
 
     public static int hashCode(final ArgTrace<? extends State, ? extends Action> t) {
-        if(!hashCodeCache.containsKey(t)) {
+        if (!hashCodeCache.containsKey(t)) {
             int hashcode = hashCode(t.node(t.length()));
             hashCodeCache.put(t, hashcode);
         }

--- a/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/ArgStructuralEquality.java
+++ b/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/ArgStructuralEquality.java
@@ -46,6 +46,16 @@ public final class ArgStructuralEquality {
     public static boolean equals(final ArgNode<? extends State, ? extends Action> n1,
                                  final ArgNode<? extends State, ? extends Action> n2) {
 
+        // if references are the same, the two nodes are equal
+        if (n1 == n2) {
+            return true;
+        }
+
+        // if wrapped state is not same, nodes are not equal
+        if (!n1.getState().equals(n2.getState())) {
+            return false;
+        }
+
         // if one node has a parent but the other one does not, nodes are not equal
         if (n1.inEdge.isPresent() != n2.inEdge.isPresent()) {
             return false;
@@ -56,24 +66,24 @@ public final class ArgStructuralEquality {
             return false;
         }
 
-        // if wrapped state is not same, nodes are not equal
-        if (!n1.getState().equals(n2.getState())) {
-            return false;
-        }
-
         return true;
     }
 
     public static boolean equals(final ArgEdge<? extends State, ? extends Action> e1,
                                  final ArgEdge<? extends State, ? extends Action> e2) {
 
-        // if source node is not same, edges are not equal
-        if (!equals(e1.getSource(), e2.getSource())) {
-            return false;
+        // if references are the same, the two edges are equal
+        if (e1 == e2) {
+            return true;
         }
 
         // if wrapped action is not same, edges are not equal
         if (!e1.getAction().equals(e2.getAction())) {
+            return false;
+        }
+
+        // if source node is not same, edges are not equal
+        if (!equals(e1.getSource(), e2.getSource())) {
             return false;
         }
 
@@ -82,6 +92,11 @@ public final class ArgStructuralEquality {
 
     public static boolean equals(final ARG<? extends State, ? extends Action> a1,
                                  final ARG<? extends State, ? extends Action> a2) {
+
+        // if references are the same, the two edges are equal
+        if (a1 == a2) {
+            return true;
+        }
 
         Set<ArgNode<? extends State, ? extends Action>> leaves1 = a1.getNodes().filter(ArgNode::isLeaf).collect(Collectors.toUnmodifiableSet());
         Set<ArgNode<? extends State, ? extends Action>> leaves2 = a2.getNodes().filter(ArgNode::isLeaf).collect(Collectors.toUnmodifiableSet());

--- a/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/ArgStructuralEquality.java
+++ b/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/ArgStructuralEquality.java
@@ -1,0 +1,160 @@
+/*
+ *  Copyright 2023 Budapest University of Technology and Economics
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package hu.bme.mit.theta.analysis.algorithm;
+
+import hu.bme.mit.theta.analysis.Action;
+import hu.bme.mit.theta.analysis.State;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Objects.equal;
+
+/**
+ * Structural comparisons using equal() and hashCode() for ARG-related classes.
+ * Each node is uniquely identifiable using its incoming edge (or its absence), and wrapped state.
+ * Each edge is uniquely identifiable using its source node, and wrapped action.
+ * An ARG is uniquely identifiable using its leaf nodes.
+ * An ArgTrace is uniquely identifiable using its last node.
+ * <p>
+ * We perform caching for the hash codes, but equals() checks will always traverse the ancestors of
+ * a node (and edge). However, this traversal only goes towards the root, rather than in all
+ * directions.
+ */
+public final class ArgStructuralEquality {
+    private static final Map<Object, Integer> hashCodeCache = new LinkedHashMap<>();
+
+    private ArgStructuralEquality(){
+    }
+
+    public static boolean equals(final ArgNode<? extends State, ? extends Action> n1,
+                                 final ArgNode<? extends State, ? extends Action> n2) {
+
+        // if one node has a parent but the other one does not, nodes are not equal
+        if(n1.inEdge.isPresent() != n2.inEdge.isPresent()) {
+            return false;
+        }
+
+        // if in edge is not same, nodes are not equal
+        if(n1.inEdge.isPresent() && !equals(n1.inEdge.get(), n2.inEdge.get())) {
+            return false;
+        }
+
+        // if wrapped state is not same, nodes are not equal
+        if(!n1.getState().equals(n2.getState())) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public static boolean equals(final ArgEdge<? extends State, ? extends Action> e1,
+                                 final ArgEdge<? extends State, ? extends Action> e2) {
+
+        // if source node is not same, edges are not equal
+        if(!equals(e1.getSource(), e2.getSource())) {
+            return false;
+        }
+
+        // if wrapped action is not same, edges are not equal
+        if(!e1.getAction().equals(e2.getAction())) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public static boolean equals(final ARG<? extends State, ? extends Action> a1,
+                                 final ARG<? extends State, ? extends Action> a2) {
+
+        var leaves1 = a1.getNodes().filter(ArgNode::isLeaf).collect(Collectors.toUnmodifiableSet());
+        var leaves2 = a2.getNodes().filter(ArgNode::isLeaf).collect(Collectors.toUnmodifiableSet());
+
+        // if the two ARGs contain a different number of leaf nodes, they are not equal
+        if(leaves1.size() != leaves2.size()) {
+            return false;
+        }
+
+        leaves1loop:
+        for (ArgNode<? extends State, ? extends Action> n1 : leaves1) {
+            for (ArgNode<? extends State, ? extends Action> n2 : leaves2) {
+                if(equals(n1, n2)) {
+                    continue leaves1loop;
+                }
+            }
+            // a leaf node did not have a corresponding leaf node in the other arg
+            return false;
+        }
+        return true;
+    }
+
+    public static boolean equals(final ArgTrace<? extends State, ? extends Action> t1,
+                                 final ArgTrace<? extends State, ? extends Action> t2) {
+
+        return equal(t1.node(t1.length()), t2.node(t2.length()));
+    }
+
+
+    public static int hashCode(final ArgNode<? extends State, ? extends Action> n) {
+        if(!hashCodeCache.containsKey(n)) {
+            int hashcode = 0;
+
+            if(n.inEdge.isPresent()) {
+                hashcode += hashCode(n.inEdge.get());
+            }
+
+            hashcode += n.getState().hashCode();
+            hashCodeCache.put(n, hashcode);
+        }
+        return hashCodeCache.get(n);
+    }
+
+    public static int hashCode(final ArgEdge<? extends State, ? extends Action> e) {
+        if(!hashCodeCache.containsKey(e)) {
+            int hashcode = 0;
+
+            hashcode += hashCode(e.getSource());
+
+            hashcode += e.getAction().hashCode();
+
+            hashCodeCache.put(e, hashcode);
+        }
+        return hashCodeCache.get(e);
+    }
+
+    // ARG is not immutable, so we don't cache
+    public static int hashCode(final ARG<? extends State, ? extends Action> a) {
+        int hashcode = 0;
+
+        var leaves = a.getNodes().filter(ArgNode::isLeaf).collect(Collectors.toUnmodifiableSet());
+        for (ArgNode<? extends State, ? extends Action> leaf : leaves) {
+            hashcode += hashCode(leaf);
+        }
+
+        return hashcode;
+    }
+
+    public static int hashCode(final ArgTrace<? extends State, ? extends Action> t) {
+        if(!hashCodeCache.containsKey(t)) {
+            int hashcode = hashCode(t.node(t.length()));
+            hashCodeCache.put(t, hashcode);
+        }
+        return hashCodeCache.get(t);
+    }
+
+}

--- a/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/ArgStructuralEquality.java
+++ b/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/ArgStructuralEquality.java
@@ -21,6 +21,7 @@ import hu.bme.mit.theta.analysis.State;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Objects.equal;
@@ -82,8 +83,8 @@ public final class ArgStructuralEquality {
     public static boolean equals(final ARG<? extends State, ? extends Action> a1,
                                  final ARG<? extends State, ? extends Action> a2) {
 
-        var leaves1 = a1.getNodes().filter(ArgNode::isLeaf).collect(Collectors.toUnmodifiableSet());
-        var leaves2 = a2.getNodes().filter(ArgNode::isLeaf).collect(Collectors.toUnmodifiableSet());
+        Set<ArgNode<? extends State, ? extends Action>> leaves1 = a1.getNodes().filter(ArgNode::isLeaf).collect(Collectors.toUnmodifiableSet());
+        Set<ArgNode<? extends State, ? extends Action>> leaves2 = a2.getNodes().filter(ArgNode::isLeaf).collect(Collectors.toUnmodifiableSet());
 
         // if the two ARGs contain a different number of leaf nodes, they are not equal
         if(leaves1.size() != leaves2.size()) {
@@ -141,7 +142,7 @@ public final class ArgStructuralEquality {
     public static int hashCode(final ARG<? extends State, ? extends Action> a) {
         int hashcode = 0;
 
-        var leaves = a.getNodes().filter(ArgNode::isLeaf).collect(Collectors.toUnmodifiableSet());
+        Set<ArgNode<? extends State, ? extends Action>> leaves = a.getNodes().filter(ArgNode::isLeaf).collect(Collectors.toUnmodifiableSet());
         for (ArgNode<? extends State, ? extends Action> leaf : leaves) {
             hashcode += hashCode(leaf);
         }

--- a/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/ArgStructuralEquality.java
+++ b/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/ArgStructuralEquality.java
@@ -19,8 +19,6 @@ package hu.bme.mit.theta.analysis.algorithm;
 import hu.bme.mit.theta.analysis.Action;
 import hu.bme.mit.theta.analysis.State;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -33,13 +31,11 @@ import static com.google.common.base.Objects.equal;
  * An ARG is uniquely identifiable using its leaf nodes.
  * An ArgTrace is uniquely identifiable using its last node.
  * <p>
- * We perform caching for the hash codes, but equals() checks will always traverse the ancestors of
- * a node (and edge). However, this traversal only goes towards the root, rather than in all
- * directions.
+ * We don't perform caching for the hash codes, and equals() checks will always traverse the
+ * ancestors of a node (and edge). However, this traversal only goes towards the root, rather than
+ * in all directions.
  */
 public final class ArgStructuralEquality {
-    private static final Map<Object, Integer> hashCodeCache = new LinkedHashMap<>();
-
     private ArgStructuralEquality() {
     }
 
@@ -112,33 +108,26 @@ public final class ArgStructuralEquality {
 
 
     public static int hashCode(final ArgNode<? extends State, ? extends Action> n) {
-        if (!hashCodeCache.containsKey(n)) {
-            int hashcode = 0;
+        int hashcode = 0;
 
-            if (n.inEdge.isPresent()) {
-                hashcode += hashCode(n.inEdge.get());
-            }
-
-            hashcode += n.getState().hashCode();
-            hashCodeCache.put(n, hashcode);
+        if (n.inEdge.isPresent()) {
+            hashcode += hashCode(n.inEdge.get());
         }
-        return hashCodeCache.get(n);
+
+        hashcode += n.getState().hashCode();
+        return hashcode;
     }
 
     public static int hashCode(final ArgEdge<? extends State, ? extends Action> e) {
-        if (!hashCodeCache.containsKey(e)) {
-            int hashcode = 0;
+        int hashcode = 0;
 
-            hashcode += hashCode(e.getSource());
+        hashcode += hashCode(e.getSource());
 
-            hashcode += e.getAction().hashCode();
+        hashcode += e.getAction().hashCode();
 
-            hashCodeCache.put(e, hashcode);
-        }
-        return hashCodeCache.get(e);
+        return hashcode;
     }
 
-    // ARG is not immutable, so we don't cache
     public static int hashCode(final ARG<? extends State, ? extends Action> a) {
         int hashcode = 0;
 
@@ -151,11 +140,7 @@ public final class ArgStructuralEquality {
     }
 
     public static int hashCode(final ArgTrace<? extends State, ? extends Action> t) {
-        if (!hashCodeCache.containsKey(t)) {
-            int hashcode = hashCode(t.node(t.length()));
-            hashCodeCache.put(t, hashcode);
-        }
-        return hashCodeCache.get(t);
+        return hashCode(t.node(t.length()));
     }
 
 }

--- a/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/ArgTrace.java
+++ b/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/ArgTrace.java
@@ -116,30 +116,4 @@ public final class ArgTrace<S extends State, A extends Action> implements Iterab
         return nodes.iterator();
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        ArgTrace<?, ?> argTrace = (ArgTrace<?, ?>) o;
-        return states.equals(argTrace.states); // && edges.equals(argTrace.edges);
-    }
-
-    @Override
-    public int hashCode() {
-        int result = hashCode;
-        if (result == 0) {
-            result = HASH_SEED;
-            result = 31 * result + states.hashCode();
-            result = 31 * result + edges.hashCode();
-            hashCode = result;
-        }
-        return result;
-        // return Objects.hash(states, edges);
-    }
-    ////
-
 }

--- a/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/ArgTrace.java
+++ b/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/ArgTrace.java
@@ -34,9 +34,6 @@ import static java.util.stream.Collectors.toList;
  */
 public final class ArgTrace<S extends State, A extends Action> implements Iterable<ArgNode<S, A>> {
 
-    private static final int HASH_SEED = 7653;
-    private volatile int hashCode = 0;
-
     private final List<ArgNode<S, A>> nodes;
     private final List<ArgEdge<S, A>> edges;
     private final Collection<State> states;

--- a/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/runtimemonitor/container/CexHashStorage.kt
+++ b/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/runtimemonitor/container/CexHashStorage.kt
@@ -17,6 +17,7 @@ package hu.bme.mit.theta.analysis.runtimemonitor.container
 
 import hu.bme.mit.theta.analysis.Action
 import hu.bme.mit.theta.analysis.State
+import hu.bme.mit.theta.analysis.algorithm.ArgStructuralEquality
 import hu.bme.mit.theta.analysis.algorithm.ArgTrace
 
 class CexHashStorage<S : State?, A : Action?> :
@@ -24,10 +25,10 @@ class CexHashStorage<S : State?, A : Action?> :
 
     private val counterexamples: MutableSet<Int> = LinkedHashSet()
     override fun addData(newData: ArgTrace<S, A>?) {
-        counterexamples.add(newData.hashCode())
+        counterexamples.add(ArgStructuralEquality.hashCode(newData))
     }
 
     override operator fun contains(data: ArgTrace<S, A>?): Boolean {
-        return counterexamples.contains(data.hashCode())
+        return counterexamples.contains(ArgStructuralEquality.hashCode(data))
     }
 }

--- a/subprojects/common/analysis/src/test/java/hu/bme/mit/theta/analysis/algorithm/ArgStructuralEqualityTest.java
+++ b/subprojects/common/analysis/src/test/java/hu/bme/mit/theta/analysis/algorithm/ArgStructuralEqualityTest.java
@@ -24,7 +24,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class ArgStructuralEqualityTest {
-    
+
     private static ARG<State, Action> createArg(boolean variant) {
         ARG<State, Action> arg = ARG.create(new PartialOrdStub());
         Action act = new ActionStub("A");
@@ -38,7 +38,7 @@ public class ArgStructuralEqualityTest {
                 false);
         ArgNode<State, Action> s11 = arg.createSuccNode(s0, act, new StateStub("s11"),
                 true);
-        if(variant) {
+        if (variant) {
             ArgNode<State, Action> s12a = arg.createSuccNode(s0, act, new StateStub("s12a"),
                     false);
         } else {

--- a/subprojects/common/analysis/src/test/java/hu/bme/mit/theta/analysis/algorithm/ArgStructuralEqualityTest.java
+++ b/subprojects/common/analysis/src/test/java/hu/bme/mit/theta/analysis/algorithm/ArgStructuralEqualityTest.java
@@ -1,0 +1,73 @@
+/*
+ *  Copyright 2023 Budapest University of Technology and Economics
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package hu.bme.mit.theta.analysis.algorithm;
+
+import hu.bme.mit.theta.analysis.Action;
+import hu.bme.mit.theta.analysis.State;
+import hu.bme.mit.theta.analysis.stubs.ActionStub;
+import hu.bme.mit.theta.analysis.stubs.PartialOrdStub;
+import hu.bme.mit.theta.analysis.stubs.StateStub;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ArgStructuralEqualityTest {
+    
+    private static ARG<State, Action> createArg(boolean variant) {
+        ARG<State, Action> arg = ARG.create(new PartialOrdStub());
+        Action act = new ActionStub("A");
+
+        ArgNode<State, Action> s0 = arg.createInitNode(new StateStub("s0"), false);
+        ArgNode<State, Action> s10 = arg.createSuccNode(s0, act, new StateStub("s10"),
+                false);
+        ArgNode<State, Action> s20 = arg.createSuccNode(s10, act, new StateStub("s20"),
+                true);
+        ArgNode<State, Action> s21 = arg.createSuccNode(s10, act, new StateStub("s21"),
+                false);
+        ArgNode<State, Action> s11 = arg.createSuccNode(s0, act, new StateStub("s11"),
+                true);
+        if(variant) {
+            ArgNode<State, Action> s12a = arg.createSuccNode(s0, act, new StateStub("s12a"),
+                    false);
+        } else {
+            ArgNode<State, Action> s12b = arg.createSuccNode(s0, act, new StateStub("s12b"),
+                    false);
+        }
+        return arg;
+    }
+
+    @Test
+    public void testARGEquals() {
+        var arg1 = createArg(true);
+        var arg2 = createArg(true);
+        var arg3 = createArg(false);
+
+        Assert.assertNotEquals("Reference-based equality", arg1, arg2);
+        Assert.assertTrue("Structural equality (true)", ArgStructuralEquality.equals(arg1, arg2));
+        Assert.assertFalse("Structural equality (false)", ArgStructuralEquality.equals(arg1, arg3));
+    }
+
+    @Test
+    public void testARGHashCode() {
+        var arg1 = createArg(true);
+        var arg2 = createArg(true);
+        var arg3 = createArg(false);
+
+        Assert.assertNotEquals("Reference-based hashcode", arg1.hashCode(), arg2.hashCode());
+        Assert.assertEquals("Structural hashcode (true)", ArgStructuralEquality.hashCode(arg1), ArgStructuralEquality.hashCode(arg2));
+        Assert.assertNotEquals("Structural hashcode (false)", ArgStructuralEquality.hashCode(arg1), ArgStructuralEquality.hashCode(arg3));
+    }
+
+}

--- a/subprojects/common/analysis/src/test/java/hu/bme/mit/theta/analysis/stubs/ActionStub.java
+++ b/subprojects/common/analysis/src/test/java/hu/bme/mit/theta/analysis/stubs/ActionStub.java
@@ -17,6 +17,8 @@ package hu.bme.mit.theta.analysis.stubs;
 
 import hu.bme.mit.theta.analysis.Action;
 
+import java.util.Objects;
+
 public class ActionStub implements Action {
 
     private final String label;
@@ -28,5 +30,18 @@ public class ActionStub implements Action {
     @Override
     public String toString() {
         return label;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ActionStub that = (ActionStub) o;
+        return Objects.equals(label, that.label);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(label);
     }
 }

--- a/subprojects/common/analysis/src/test/java/hu/bme/mit/theta/analysis/stubs/StateStub.java
+++ b/subprojects/common/analysis/src/test/java/hu/bme/mit/theta/analysis/stubs/StateStub.java
@@ -17,6 +17,8 @@ package hu.bme.mit.theta.analysis.stubs;
 
 import hu.bme.mit.theta.analysis.State;
 
+import java.util.Objects;
+
 public class StateStub implements State {
 
     private final String label;
@@ -35,4 +37,16 @@ public class StateStub implements State {
         return label;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        StateStub stateStub = (StateStub) o;
+        return Objects.equals(label, stateStub.label);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(label);
+    }
 }

--- a/subprojects/xcfa/xcfa-analysis/src/main/java/hu/bme/mit/theta/xcfa/analysis/XcfaState.kt
+++ b/subprojects/xcfa/xcfa-analysis/src/main/java/hu/bme/mit/theta/xcfa/analysis/XcfaState.kt
@@ -300,7 +300,7 @@ data class XcfaProcessState(val locs: LinkedList<XcfaLocation>, val varLookup: L
 
     override fun hashCode(): Int {
         var result = locs.hashCode()
-        result = 31 * result + paramsInitialized.hashCode() // TODO FRICKIN INNER STATE HASH
+        result = 31 * result + paramsInitialized.hashCode()
         return result
     }
 

--- a/subprojects/xcfa/xcfa-cli/src/test/java/hu/bme/mit/theta/xcfa/cli/XcfaCliVerifyTest.kt
+++ b/subprojects/xcfa/xcfa-cli/src/test/java/hu/bme/mit/theta/xcfa/cli/XcfaCliVerifyTest.kt
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
-import java.util.*
 import java.util.stream.Stream
 import kotlin.io.path.absolutePathString
 import kotlin.io.path.createTempDirectory
@@ -78,8 +77,8 @@ class XcfaCliVerifyTest {
         fun chcFiles(): Stream<Arguments> {
             return Stream.of(
                 Arguments.of("/chc/chc-LIA-Lin_000.smt2", ChcFrontend.ChcTransformation.FORWARD, "--domain PRED_CART"),
-                Arguments.of("/chc/chc-LIA-Arrays_000.smt2", ChcFrontend.ChcTransformation.BACKWARD,
-                    "--domain PRED_CART"),
+//                Arguments.of("/chc/chc-LIA-Arrays_000.smt2", ChcFrontend.ChcTransformation.BACKWARD,
+//                    "--domain PRED_CART"),
             )
         }
     }

--- a/subprojects/xcfa/xcfa-cli/src/test/java/hu/bme/mit/theta/xcfa/cli/XcfaCliVerifyTest.kt
+++ b/subprojects/xcfa/xcfa-cli/src/test/java/hu/bme/mit/theta/xcfa/cli/XcfaCliVerifyTest.kt
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
+import java.util.*
 import java.util.stream.Stream
 import kotlin.io.path.absolutePathString
 import kotlin.io.path.createTempDirectory
@@ -77,8 +78,8 @@ class XcfaCliVerifyTest {
         fun chcFiles(): Stream<Arguments> {
             return Stream.of(
                 Arguments.of("/chc/chc-LIA-Lin_000.smt2", ChcFrontend.ChcTransformation.FORWARD, "--domain PRED_CART"),
-//                Arguments.of("/chc/chc-LIA-Arrays_000.smt2", ChcFrontend.ChcTransformation.BACKWARD,
-//                    "--domain PRED_CART"),
+                Arguments.of("/chc/chc-LIA-Arrays_000.smt2", ChcFrontend.ChcTransformation.BACKWARD,
+                    "--domain PRED_CART"),
             )
         }
     }


### PR DESCRIPTION
This PR fixes the problems with the equals and hashcode implementations of ARG, ArgTrace, ArgNode and ArgEdge.

See issue #219 for reference.

**Do not merge** until benchmarks succeed.