### PR TITLE
Fix smtinterpol interpolation (#253)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ buildscript {
 
 allprojects {
     group = "hu.bme.mit.theta"
-    version = "5.0.5"
+    version = "5.0.6"
 
     apply(from = rootDir.resolve("gradle/shared-with-buildSrc/mirrors.gradle.kts"))
 }

--- a/subprojects/solver/solver-smtlib/src/main/java/hu/bme/mit/theta/solver/smtlib/impl/smtinterpol/SMTInterpolSmtLibItpSolver.java
+++ b/subprojects/solver/solver-smtlib/src/main/java/hu/bme/mit/theta/solver/smtlib/impl/smtinterpol/SMTInterpolSmtLibItpSolver.java
@@ -44,6 +44,7 @@ import org.antlr.v4.runtime.misc.Interval;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -57,7 +58,7 @@ import static hu.bme.mit.theta.core.type.booltype.BoolExprs.False;
 
 public final class SMTInterpolSmtLibItpSolver extends SmtLibItpSolver<SMTInterpolSmtLibItpMarker> {
 
-    private final Map<Expr<BoolType>, String> assertionNames = new HashMap<>();
+    private final Map<Expr<BoolType>, String> assertionNames = new IdentityHashMap<>();
     private static final String assertionNamePattern = "_smtinterpol_assertion_%d";
     private static long assertionCount = 0;
 


### PR DESCRIPTION
This fixes the issue with #253.
The solution was to change the map to an identity map, thus not referring to other instances of the expression in an interpolant (beforehand, due to equalities among expressions, the last occurrence was always used). 