### PR TITLE
Horn checker

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ buildscript {
 
 allprojects {
     group = "hu.bme.mit.theta"
-    version = "6.0.0"
+    version = "6.1.0"
 
     apply(from = rootDir.resolve("gradle/shared-with-buildSrc/mirrors.gradle.kts"))
 }

--- a/subprojects/common/analysis/build.gradle.kts
+++ b/subprojects/common/analysis/build.gradle.kts
@@ -29,5 +29,6 @@ dependencies {
     implementation(project(":theta-graph-solver"))
     implementation(project(mapOf("path" to ":theta-solver-z3-legacy")))
     testImplementation(project(":theta-solver-z3-legacy"))
+    testImplementation(project(":theta-solver-z3"))
     implementation("com.corundumstudio.socketio:netty-socketio:2.0.6")
 }

--- a/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/chc/HornChecker.kt
+++ b/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/chc/HornChecker.kt
@@ -33,6 +33,7 @@ import hu.bme.mit.theta.solver.SolverStatus
 data class Invariant(val lookup: Map<Relation, Expr<BoolType>>) : Witness
 
 data class CexTree(val proofNode: ProofNode) : Cex {
+
     override fun length(): Int = proofNode.depth()
 }
 
@@ -66,13 +67,16 @@ class HornChecker(
             SolverStatus.SAT -> {
                 logger.write(Logger.Level.MAINSTEP, "Proof (model) found\n")
                 val model = solver.model.toMap()
-                SafetyResult.safe(Invariant(relations.associateWith { model[it.constDecl] as? Expr<BoolType> ?: True() }))
+                SafetyResult.safe(
+                    Invariant(relations.associateWith { model[it.constDecl] as? Expr<BoolType> ?: True() }))
             }
+
             SolverStatus.UNSAT -> {
                 logger.write(Logger.Level.MAINSTEP, "Counterexample found\n")
                 val proof = solver.proof
                 SafetyResult.unsafe(CexTree(proof), Invariant(emptyMap()))
             }
+
             else -> {
                 logger.write(Logger.Level.MAINSTEP, "No solution found.\n")
                 SafetyResult.unknown()

--- a/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/chc/HornChecker.kt
+++ b/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/chc/HornChecker.kt
@@ -1,0 +1,83 @@
+/*
+ *  Copyright 2024 Budapest University of Technology and Economics
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package hu.bme.mit.theta.analysis.algorithm.chc
+
+import hu.bme.mit.theta.analysis.Cex
+import hu.bme.mit.theta.analysis.algorithm.SafetyChecker
+import hu.bme.mit.theta.analysis.algorithm.SafetyResult
+import hu.bme.mit.theta.analysis.algorithm.Witness
+import hu.bme.mit.theta.analysis.unit.UnitPrec
+import hu.bme.mit.theta.common.logging.Logger
+import hu.bme.mit.theta.core.Relation
+import hu.bme.mit.theta.core.type.Expr
+import hu.bme.mit.theta.core.type.booltype.BoolExprs.True
+import hu.bme.mit.theta.core.type.booltype.BoolType
+import hu.bme.mit.theta.solver.ProofNode
+import hu.bme.mit.theta.solver.SolverFactory
+import hu.bme.mit.theta.solver.SolverStatus
+
+data class Invariant(val lookup: Map<Relation, Expr<BoolType>>) : Witness
+
+data class CexTree(val proofNode: ProofNode) : Cex {
+    override fun length(): Int = proofNode.depth()
+}
+
+/**
+ * A checker for CHC-based verification.
+ */
+class HornChecker(
+    private val relations: List<Relation>,
+    private val hornSolverFactory: SolverFactory,
+    private val logger: Logger,
+) : SafetyChecker<Invariant, CexTree, UnitPrec> {
+
+    override fun check(prec: UnitPrec?): SafetyResult<Invariant, CexTree> {
+        val solver = hornSolverFactory.createHornSolver()
+        logger.write(Logger.Level.MAINSTEP, "Starting encoding\n")
+        solver.add(relations)
+        logger.write(Logger.Level.DETAIL, "Relations:\n\t${
+            relations.joinToString("\n\t") {
+                it.constDecl.toString()
+            }
+        }\n")
+        logger.write(Logger.Level.DETAIL, "Rules:\n\t${
+            solver.assertions.joinToString("\n\t") {
+                it.toString().replace(Regex("[\r\n\t ]+"), " ")
+            }
+        }\n")
+        logger.write(Logger.Level.MAINSTEP, "Added constraints to solver\n")
+        solver.check()
+        logger.write(Logger.Level.MAINSTEP, "Check() finished (result: ${solver.status})\n")
+        return when (solver.status) {
+            SolverStatus.SAT -> {
+                logger.write(Logger.Level.MAINSTEP, "Proof (model) found\n")
+                val model = solver.model.toMap()
+                SafetyResult.safe(Invariant(relations.associateWith { model[it.constDecl] as? Expr<BoolType> ?: True() }))
+            }
+            SolverStatus.UNSAT -> {
+                logger.write(Logger.Level.MAINSTEP, "Counterexample found\n")
+                val proof = solver.proof
+                SafetyResult.unsafe(CexTree(proof), Invariant(emptyMap()))
+            }
+            else -> {
+                logger.write(Logger.Level.MAINSTEP, "No solution found.\n")
+                SafetyResult.unknown()
+            }
+        }
+    }
+
+}

--- a/subprojects/common/analysis/src/test/java/hu/bme/mit/theta/analysis/algorithm/HornTest.kt
+++ b/subprojects/common/analysis/src/test/java/hu/bme/mit/theta/analysis/algorithm/HornTest.kt
@@ -1,0 +1,56 @@
+/*
+ *  Copyright 2024 Budapest University of Technology and Economics
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package hu.bme.mit.theta.analysis.algorithm
+
+import hu.bme.mit.theta.analysis.algorithm.chc.HornChecker
+import hu.bme.mit.theta.common.logging.NullLogger
+import hu.bme.mit.theta.core.Relation
+import hu.bme.mit.theta.core.decl.Decls.Param
+import hu.bme.mit.theta.core.plus
+import hu.bme.mit.theta.core.type.inttype.IntExprs.*
+import hu.bme.mit.theta.solver.z3.Z3SolverFactory
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class HornTest {
+
+    @Test
+    fun testHornUnsafe() {
+        val inv = Relation("inv", Int())
+        val p0 = Param("P0", Int())
+        val p1 = Param("P1", Int())
+        inv(p0.ref) += Eq(p0.ref, Int(0))
+        inv(p1.ref) += inv(p0.ref).expr + Eq(p1.ref, Add(p0.ref, Int(1)))
+        !(inv(p0.ref) with Eq(p0.ref, Int(5)))
+
+        val checker = HornChecker(listOf(inv), Z3SolverFactory.getInstance(), NullLogger.getInstance())
+        Assertions.assertTrue(checker.check().isUnsafe)
+    }
+
+    @Test
+    fun testHornSafe() {
+        val inv = Relation("inv", Int())
+        val p0 = Param("P0", Int())
+        val p1 = Param("P1", Int())
+        inv(p0.ref) += Eq(p0.ref, Int(0))
+        inv(p1.ref) += inv(p0.ref).expr + Eq(p1.ref, Add(p0.ref, Int(2)))
+        !(inv(p0.ref) with Eq(p0.ref, Int(5)))
+
+        val checker = HornChecker(listOf(inv), Z3SolverFactory.getInstance(), NullLogger.getInstance())
+        Assertions.assertTrue(checker.check().isSafe)
+    }
+}

--- a/subprojects/common/analysis/src/test/java/hu/bme/mit/theta/analysis/algorithm/HornTest.kt
+++ b/subprojects/common/analysis/src/test/java/hu/bme/mit/theta/analysis/algorithm/HornTest.kt
@@ -17,6 +17,7 @@
 package hu.bme.mit.theta.analysis.algorithm
 
 import hu.bme.mit.theta.analysis.algorithm.chc.HornChecker
+import hu.bme.mit.theta.common.OsHelper
 import hu.bme.mit.theta.common.logging.NullLogger
 import hu.bme.mit.theta.core.Relation
 import hu.bme.mit.theta.core.decl.Decls.Param
@@ -24,12 +25,15 @@ import hu.bme.mit.theta.core.plus
 import hu.bme.mit.theta.core.type.inttype.IntExprs.*
 import hu.bme.mit.theta.solver.z3.Z3SolverFactory
 import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.Test
 
 class HornTest {
 
     @Test
     fun testHornUnsafe() {
+        Assumptions.assumeTrue(OsHelper.getOs().equals(OsHelper.OperatingSystem.LINUX));
+
         val inv = Relation("inv", Int())
         val p0 = Param("P0", Int())
         val p1 = Param("P1", Int())
@@ -43,6 +47,8 @@ class HornTest {
 
     @Test
     fun testHornSafe() {
+        Assumptions.assumeTrue(OsHelper.getOs().equals(OsHelper.OperatingSystem.LINUX));
+
         val inv = Relation("inv", Int())
         val p0 = Param("P0", Int())
         val p1 = Param("P1", Int())

--- a/subprojects/solver/solver-smtlib/src/main/antlr/SMTLIBv2.g4
+++ b/subprojects/solver/solver-smtlib/src/main/antlr/SMTLIBv2.g4
@@ -573,7 +573,7 @@ GRW_String
 
 Numeral
     : '0'
-    | [1-9] Digit*
+    | '-'? [1-9] Digit*
     ;
 
 Binary

--- a/subprojects/solver/solver-z3/src/main/java/hu/bme/mit/theta/solver/z3/Z3SolverManager.java
+++ b/subprojects/solver/solver-z3/src/main/java/hu/bme/mit/theta/solver/z3/Z3SolverManager.java
@@ -15,6 +15,7 @@
  */
 package hu.bme.mit.theta.solver.z3;
 
+import hu.bme.mit.theta.solver.HornSolver;
 import hu.bme.mit.theta.solver.ItpSolver;
 import hu.bme.mit.theta.solver.Solver;
 import hu.bme.mit.theta.solver.SolverBase;
@@ -89,6 +90,14 @@ public final class Z3SolverManager extends SolverManager {
         public ItpSolver createItpSolver() {
             checkState(!closed, "Solver manager was closed");
             final var solver = solverFactory.createItpSolver();
+            instantiatedSolvers.add(solver);
+            return solver;
+        }
+
+        @Override
+        public HornSolver createHornSolver() {
+            checkState(!closed, "Solver manager was closed");
+            final var solver = solverFactory.createHornSolver();
             instantiatedSolvers.add(solver);
             return solver;
         }

--- a/subprojects/solver/solver/src/main/java/hu/bme/mit/theta/solver/ProofNode.java
+++ b/subprojects/solver/solver/src/main/java/hu/bme/mit/theta/solver/ProofNode.java
@@ -32,6 +32,10 @@ public record ProofNode(int id, Expr<BoolType> expr, List<ProofNode> children) {
         return And(Stream.concat(Stream.of(expr), children.stream().flatMap(it -> it.toExpr().getOps().stream())).toList());
     }
 
+    public int depth() {
+        return children.stream().map(ProofNode::depth).max(Integer::compareTo).orElse(0);
+    }
+
     public String toString() {
         final var sj = new StringJoiner(", ");
         children.stream().map(ProofNode::id).forEach(it -> sj.add(it.toString()));

--- a/subprojects/xcfa/xcfa-cli/src/main/java/hu/bme/mit/theta/xcfa/cli/checkers/ConfigToChecker.kt
+++ b/subprojects/xcfa/xcfa-cli/src/main/java/hu/bme/mit/theta/xcfa/cli/checkers/ConfigToChecker.kt
@@ -44,6 +44,7 @@ fun getChecker(xcfa: XCFA, mcm: MCM, config: XcfaConfig<*, *>, parseContext: Par
             Backend.LAZY -> TODO()
             Backend.PORTFOLIO -> getPortfolioChecker(xcfa, mcm, config, parseContext, logger, uniqueLogger)
             Backend.NONE -> SafetyChecker<ARG<XcfaState<PtrState<*>>, XcfaAction>, Trace<XcfaState<PtrState<*>>, XcfaAction>, XcfaPrec<*>> { _ -> SafetyResult.unknown() }
+            Backend.CHC -> getHornChecker(xcfa, mcm, config, logger)
         }
     }
 

--- a/subprojects/xcfa/xcfa-cli/src/main/java/hu/bme/mit/theta/xcfa/cli/checkers/ConfigToHornChecker.kt
+++ b/subprojects/xcfa/xcfa-cli/src/main/java/hu/bme/mit/theta/xcfa/cli/checkers/ConfigToHornChecker.kt
@@ -1,0 +1,68 @@
+/*
+ *  Copyright 2024 Budapest University of Technology and Economics
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package hu.bme.mit.theta.xcfa.cli.checkers
+
+import hu.bme.mit.theta.analysis.Trace
+import hu.bme.mit.theta.analysis.algorithm.EmptyWitness
+import hu.bme.mit.theta.analysis.algorithm.SafetyChecker
+import hu.bme.mit.theta.analysis.algorithm.SafetyResult
+import hu.bme.mit.theta.analysis.algorithm.chc.HornChecker
+import hu.bme.mit.theta.analysis.pred.PredState
+import hu.bme.mit.theta.analysis.ptr.PtrState
+import hu.bme.mit.theta.common.logging.Logger
+import hu.bme.mit.theta.graphsolver.patterns.constraints.MCM
+import hu.bme.mit.theta.xcfa.analysis.XcfaAction
+import hu.bme.mit.theta.xcfa.analysis.XcfaPrec
+import hu.bme.mit.theta.xcfa.analysis.XcfaState
+import hu.bme.mit.theta.xcfa.analysis.isInlined
+import hu.bme.mit.theta.xcfa.cli.params.HornConfig
+import hu.bme.mit.theta.xcfa.cli.params.XcfaConfig
+import hu.bme.mit.theta.xcfa.cli.utils.getSolver
+import hu.bme.mit.theta.xcfa.model.XCFA
+import hu.bme.mit.theta.xcfa2chc.toCHC
+import org.abego.treelayout.internal.util.Contract.checkState
+
+fun getHornChecker(xcfa: XCFA, mcm: MCM, config: XcfaConfig<*, *>, logger: Logger):
+    SafetyChecker<EmptyWitness, Trace<XcfaState<out PtrState<*>>, XcfaAction>, XcfaPrec<*>> {
+
+    checkState(xcfa.isInlined, "Only inlined XCFAs work right now")
+    checkState(xcfa.initProcedures.size == 1, "Only one-procedure XCFAs work right now")
+
+    val hornConfig = config.backendConfig.specConfig as HornConfig
+
+    val checker = HornChecker(
+        relations = xcfa.initProcedures[0].first.toCHC(),
+        hornSolverFactory = getSolver(hornConfig.solver, hornConfig.validateSolver),
+        logger = logger,
+    )
+
+    return SafetyChecker<EmptyWitness, Trace<XcfaState<out PtrState<*>>, XcfaAction>, XcfaPrec<*>> {
+        val result = checker.check(null)
+
+        if(result.isSafe) {
+            SafetyResult.safe(EmptyWitness.getInstance())
+        } else if (result.isUnsafe) {
+            val proof = result.asUnsafe().cex
+            val state = XcfaState<PtrState<PredState>>(xcfa, mapOf(), PtrState(PredState.of(proof.proofNode.expr)))
+            //TODO: actual counterexample
+            SafetyResult.unsafe(Trace.of(listOf(state), listOf()), EmptyWitness.getInstance())
+        } else{
+            SafetyResult.unknown()
+        }
+    }
+
+}

--- a/subprojects/xcfa/xcfa-cli/src/main/java/hu/bme/mit/theta/xcfa/cli/checkers/ConfigToHornChecker.kt
+++ b/subprojects/xcfa/xcfa-cli/src/main/java/hu/bme/mit/theta/xcfa/cli/checkers/ConfigToHornChecker.kt
@@ -53,13 +53,13 @@ fun getHornChecker(xcfa: XCFA, mcm: MCM, config: XcfaConfig<*, *>, logger: Logge
     return SafetyChecker<EmptyWitness, Trace<XcfaState<out PtrState<*>>, XcfaAction>, XcfaPrec<*>> {
         val result = checker.check(null)
 
-        if(result.isSafe) {
+        if (result.isSafe) {
             SafetyResult.safe(EmptyWitness.getInstance())
         } else if (result.isUnsafe) {
             val proof = result.asUnsafe().cex
             val state = XcfaState<PtrState<PredState>>(xcfa, mapOf(), PtrState(PredState.of(proof.proofNode.expr)))
             SafetyResult.unsafe(Trace.of(listOf(state), listOf()), EmptyWitness.getInstance())
-        } else{
+        } else {
             SafetyResult.unknown()
         }
     }

--- a/subprojects/xcfa/xcfa-cli/src/main/java/hu/bme/mit/theta/xcfa/cli/checkers/ConfigToHornChecker.kt
+++ b/subprojects/xcfa/xcfa-cli/src/main/java/hu/bme/mit/theta/xcfa/cli/checkers/ConfigToHornChecker.kt
@@ -58,7 +58,6 @@ fun getHornChecker(xcfa: XCFA, mcm: MCM, config: XcfaConfig<*, *>, logger: Logge
         } else if (result.isUnsafe) {
             val proof = result.asUnsafe().cex
             val state = XcfaState<PtrState<PredState>>(xcfa, mapOf(), PtrState(PredState.of(proof.proofNode.expr)))
-            //TODO: actual counterexample
             SafetyResult.unsafe(Trace.of(listOf(state), listOf()), EmptyWitness.getInstance())
         } else{
             SafetyResult.unknown()

--- a/subprojects/xcfa/xcfa-cli/src/main/java/hu/bme/mit/theta/xcfa/cli/params/ParamValues.kt
+++ b/subprojects/xcfa/xcfa-cli/src/main/java/hu/bme/mit/theta/xcfa/cli/params/ParamValues.kt
@@ -66,6 +66,7 @@ enum class InputType {
 enum class Backend {
     CEGAR,
     BOUNDED,
+    CHC,
     OC,
     LAZY,
     PORTFOLIO,

--- a/subprojects/xcfa/xcfa-cli/src/main/java/hu/bme/mit/theta/xcfa/cli/params/XcfaConfig.kt
+++ b/subprojects/xcfa/xcfa-cli/src/main/java/hu/bme/mit/theta/xcfa/cli/params/XcfaConfig.kt
@@ -165,6 +165,7 @@ data class BackendConfig<T : SpecBackendConfig>(
         specConfig = when (backend) {
             Backend.CEGAR -> CegarConfig() as T
             Backend.BOUNDED -> BoundedConfig() as T
+            Backend.CHC -> HornConfig() as T
             Backend.OC -> OcConfig() as T
             Backend.LAZY -> null
             Backend.PORTFOLIO -> PortfolioConfig() as T
@@ -241,6 +242,16 @@ data class CegarRefinerConfig(
     @Parameter(names = ["--prunestrategy"], description = "Strategy for pruning the ARG after refinement")
     var pruneStrategy: PruneStrategy = PruneStrategy.LAZY,
 ) : Config
+
+data class HornConfig(
+    @Parameter(names = ["--solver"], description = "Solver to use.")
+    var solver: String = "Z3:4.13",
+    @Parameter(
+        names = ["--validate-solver"],
+        description = "Activates a wrapper, which validates the assertions in the solver in each (SAT) check. Filters some solver issues."
+    )
+    var validateSolver: Boolean = false,
+) : SpecBackendConfig
 
 data class BoundedConfig(
     @Parameter(names = ["--max-bound"], description = "Maximum bound to check. Use 0 for no limit.")

--- a/subprojects/xcfa/xcfa-cli/src/test/java/hu/bme/mit/theta/xcfa/cli/XcfaCliVerifyTest.kt
+++ b/subprojects/xcfa/xcfa-cli/src/test/java/hu/bme/mit/theta/xcfa/cli/XcfaCliVerifyTest.kt
@@ -15,9 +15,11 @@
  */
 package hu.bme.mit.theta.xcfa.cli
 
+import hu.bme.mit.theta.common.OsHelper
 import hu.bme.mit.theta.frontend.chc.ChcFrontend
 import hu.bme.mit.theta.xcfa.cli.XcfaCli.Companion.main
 import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -84,6 +86,19 @@ class XcfaCliVerifyTest {
                 Arguments.of("/c/litmustest/singlethread/02types.c", null),
                 Arguments.of("/c/litmustest/singlethread/03bitwise.c", null),
                 Arguments.of("/c/litmustest/singlethread/04real.c", null),
+            )
+        }
+
+        @JvmStatic
+        fun cFilesShortInt(): Stream<Arguments> {
+            return Stream.of(
+                Arguments.of("/c/litmustest/singlethread/00assignment.c", null),
+                Arguments.of("/c/litmustest/singlethread/01cast.c", null),
+                Arguments.of("/c/litmustest/singlethread/02types.c", null),
+                Arguments.of("/c/litmustest/singlethread/15addition.c", null),
+                Arguments.of("/c/litmustest/singlethread/20testinline.c", null),
+                Arguments.of("/c/litmustest/singlethread/21namecollision.c", null),
+                Arguments.of("/c/litmustest/singlethread/22nondet.c", null),
             )
         }
 
@@ -231,6 +246,21 @@ class XcfaCliVerifyTest {
     fun testCVerifyIMCThenKind(filePath: String, extraArgs: String?) {
         val params = arrayOf(
             "--backend", "BOUNDED",
+            "--input-type", "C",
+            "--input", javaClass.getResource(filePath)!!.path,
+            "--stacktrace",
+            "--debug"
+        )
+        main(params)
+    }
+
+    @ParameterizedTest
+    @MethodSource("cFilesShortInt")
+    fun testCVerifyCHC(filePath: String, extraArgs: String?) {
+        Assumptions.assumeTrue(OsHelper.getOs().equals(OsHelper.OperatingSystem.LINUX));
+
+        val params = arrayOf(
+            "--backend", "CHC",
             "--input-type", "C",
             "--input", javaClass.getResource(filePath)!!.path,
             "--stacktrace",


### PR DESCRIPTION
This adds a new SafetyChecker, called HornChecker. Bindings for XCFA were also added.

Right now tested and works with Eldarica, Golem and Z3/SPACER. 

Some aspects of SmtLib parsing were modified/fixed/adapted.