### PR TITLE
CTL checker

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,7 +47,7 @@ buildscript {
 
 allprojects {
     group = "hu.bme.mit.theta"
-    version = "7.0.4"
+    version = "7.1.0"
 
     apply(from = rootDir.resolve("gradle/shared-with-buildSrc/mirrors.gradle.kts"))
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,6 +23,7 @@ include(
     "common/multi-tests",
     "common/ltl",
     "common/ltl-cli",
+    "common/ctl",
 
     "frontends/btor2-frontend",
     "frontends/c-frontend",

--- a/subprojects/cfa/cfa-cli/src/main/java/hu/bme/mit/theta/cfa/cli/CfaCli.java
+++ b/subprojects/cfa/cfa-cli/src/main/java/hu/bme/mit/theta/cfa/cli/CfaCli.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2025 Budapest University of Technology and Economics
+ *  Copyright 2026 Budapest University of Technology and Economics
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/subprojects/cfa/cfa-cli/src/main/java/hu/bme/mit/theta/cfa/cli/CfaCli.java
+++ b/subprojects/cfa/cfa-cli/src/main/java/hu/bme/mit/theta/cfa/cli/CfaCli.java
@@ -35,6 +35,7 @@ import hu.bme.mit.theta.analysis.algorithm.bounded.pipeline.passes.ReverseMEPass
 import hu.bme.mit.theta.analysis.algorithm.cegar.CegarStatistics;
 import hu.bme.mit.theta.analysis.algorithm.ic3.Ic3Checker;
 import hu.bme.mit.theta.analysis.algorithm.mdd.MddChecker;
+import hu.bme.mit.theta.analysis.algorithm.mdd.fixedpoint.IterationStrategy;
 import hu.bme.mit.theta.analysis.expl.ExplState;
 import hu.bme.mit.theta.analysis.expr.ExprAction;
 import hu.bme.mit.theta.analysis.expr.refinement.ExprTraceCheckerFactoriesKt;
@@ -288,7 +289,7 @@ public class CfaCli {
     @Parameter(
             names = {"--iteration-strategy"},
             description = "MDD iteration strategy")
-    MddChecker.IterationStrategy iterationStrategy = MddChecker.IterationStrategy.GSAT;
+    IterationStrategy iterationStrategy = IterationStrategy.GSAT;
 
     @Parameter(names = "--loglevel", description = "Detailedness of logging")
     Logger.Level logLevel = Level.SUBSTEP;

--- a/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/mdd/MddChecker.kt
+++ b/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/mdd/MddChecker.kt
@@ -68,12 +68,6 @@ constructor(
   private val solverMeasurements: Boolean = false,
 ) : SafetyChecker<MddProof, Trace<ExplState, ExprAction>, UnitPrec> {
 
-  enum class IterationStrategy {
-    BFS,
-    SAT,
-    GSAT,
-  }
-
   override fun check(prec: UnitPrec?): SafetyResult<MddProof, Trace<ExplState, ExprAction>> {
     val totalTime = Stopwatch.createStarted()
 
@@ -160,18 +154,7 @@ constructor(
       else OnTheFlyReachabilityNextStateDescriptor.of(nextStates, propNode)
 
     logger.write(Logger.Level.INFO, "Created next-state node, starting fixed point calculation\n")
-    val stateSpaceProvider =
-      when (iterationStrategy) {
-        IterationStrategy.BFS -> {
-          BfsProvider(stateSig.variableOrder)
-        }
-        IterationStrategy.SAT -> {
-          SimpleSaturationProvider(stateSig.variableOrder)
-        }
-        IterationStrategy.GSAT -> {
-          GeneralizedSaturationProvider(stateSig.variableOrder)
-        }
-      }
+    val stateSpaceProvider = iterationStrategy.createProvider(stateSig.variableOrder)
 
     val stateSpace =
       stateSpaceProvider.compute(
@@ -293,12 +276,7 @@ constructor(
     val structNextStates: AbstractNextStateDescriptor =
       OrNextStateDescriptor.create(structDescriptors)
 
-    val rerunProvider =
-      when (iterationStrategy) {
-        IterationStrategy.BFS -> BfsProvider(stateSig.variableOrder)
-        IterationStrategy.SAT -> SimpleSaturationProvider(stateSig.variableOrder)
-        IterationStrategy.GSAT -> GeneralizedSaturationProvider(stateSig.variableOrder)
-      }
+    val rerunProvider = iterationStrategy.createProvider(stateSig.variableOrder)
 
     val rerunSolverCountBefore = solverPool.checkCount
     val rerunTime = Stopwatch.createStarted()

--- a/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/mdd/ansd/impl/AndNextStateDescriptor.java
+++ b/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/mdd/ansd/impl/AndNextStateDescriptor.java
@@ -27,27 +27,13 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * Constrained next-state descriptor: restricts the image of a wrapped relation to the states of a
- * {@code constraint} set, descending the constraint node in lockstep with the relation, level by
- * level. This is the "constrained saturation" hook used for CTL EU: wrapping the reversed
- * transition relation with the constraint {@code phi ∪ psi} lets the unmodified {@link
- * hu.bme.mit.theta.analysis.algorithm.mdd.fixedpoint.GeneralizedSaturationProvider} compute the
- * least fixed point {@code mu Z. psi | (phi & pre(Z))} in a single call.
+ * Restricts the image of a wrapped relation to the states of a {@code constraint} set, descending
+ * the constraint node in lockstep with the relation. Used for constrained saturation (CTL EU).
  *
- * <p>Modeled on {@link OnTheFlyReachabilityNextStateDescriptor}, with two essential differences:
- *
- * <ul>
- *   <li>The constraint is part of the relation's meaning, so it is included in {@link #equals}/
- *       {@link #hashCode} (otherwise distinct constraints collide in the saturation cache).
- *   <li>Pruning is by <b>key absence</b>: the diagonal / off-diagonal maps are trimmed to the
- *       constraint's key set, so a step into a state outside the constraint simply does not appear.
- *       This satisfies two joint requirements of the (unmodified) saturation engine that the naive
- *       approach violates: {@code satFire} asserts off-diagonal <i>values</i> are never {@code
- *       terminalEmpty} (so we must not map a pruned key to {@code terminalEmpty}), and {@code
- *       relProd} assumes every branch it descends reaches a terminal with {@code evaluate() ==
- *       true} (so we must not let a pruned branch be descended at all — it would hit a terminal
- *       whose constraint slice is zero). Dropping the key entirely avoids both.
- * </ul>
+ * <p>The views prune constraint-zero keys by key absence: satFire asserts that off-diagonal values
+ * are never {@code terminalEmpty}, and relProd assumes every descended branch reaches a terminal
+ * with {@code evaluate() == true}. The constraint is part of equals/hashCode, otherwise distinct
+ * constraints collide in the saturation cache.
  */
 public final class AndNextStateDescriptor implements AbstractNextStateDescriptor {
 
@@ -62,12 +48,7 @@ public final class AndNextStateDescriptor implements AbstractNextStateDescriptor
 
     public static AbstractNextStateDescriptor of(
             AbstractNextStateDescriptor wrapped, MddHandle constraint) {
-        // Only short-circuit on an empty *relation*. Do NOT short-circuit on a zero constraint
-        // here:
-        // that would inject terminalEmpty into the off-diagonal map and trip saturation's
-        // assertion.
-        // A zero constraint is pruned later, in evaluate().
-        if (wrapped == AbstractNextStateDescriptor.terminalEmpty()) {
+        if (wrapped == AbstractNextStateDescriptor.terminalEmpty() || constraint.isTerminalZero()) {
             return AbstractNextStateDescriptor.terminalEmpty();
         }
         return new AndNextStateDescriptor(wrapped, constraint);
@@ -75,8 +56,6 @@ public final class AndNextStateDescriptor implements AbstractNextStateDescriptor
 
     @Override
     public IntObjMapView<AbstractNextStateDescriptor> getDiagonal(StateSpaceInfo localStateSpace) {
-        // Keep only keys present in the constraint (its non-zero children), then thread the
-        // corresponding constraint slice into each surviving continuation.
         return new IntObjMapViews.Transforming<>(
                 wrapped.getDiagonal(localStateSpace).trim(constraint.keySet()),
                 (descriptor, key) -> {
@@ -88,9 +67,8 @@ public final class AndNextStateDescriptor implements AbstractNextStateDescriptor
     @Override
     public IntObjMapView<IntObjMapView<AbstractNextStateDescriptor>> getOffDiagonal(
             StateSpaceInfo localStateSpace) {
-        // The constraint restricts the *target* (the new state reached), i.e. the inner key. The
-        // reversed relation's inner off-diagonal view supports only cursor()/get() (not trim), so
-        // we filter with a cursor that skips constraint-zero targets rather than trimming.
+        // the constraint restricts the target (the inner key); the inner view supports only
+        // cursor()/get(), so constraint-zero targets are skipped with a cursor instead of trim
         return new IntObjMapViews.Transforming<>(
                 wrapped.getOffDiagonal(localStateSpace), this::constrainInner);
     }
@@ -176,8 +154,6 @@ public final class AndNextStateDescriptor implements AbstractNextStateDescriptor
 
     @Override
     public boolean evaluate() {
-        // The relation accepts iff the wrapped relation accepts AND the fully-descended state lies
-        // in the constraint set (its terminal slice is non-zero).
         return wrapped.evaluate() && !constraint.isTerminalZero();
     }
 

--- a/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/mdd/ansd/impl/AndNextStateDescriptor.java
+++ b/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/mdd/ansd/impl/AndNextStateDescriptor.java
@@ -1,0 +1,201 @@
+/*
+ *  Copyright 2026 Budapest University of Technology and Economics
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package hu.bme.mit.theta.analysis.algorithm.mdd.ansd.impl;
+
+import com.google.common.base.Preconditions;
+import hu.bme.mit.delta.collections.IntObjCursor;
+import hu.bme.mit.delta.collections.IntObjMapView;
+import hu.bme.mit.delta.collections.impl.IntObjMapViews;
+import hu.bme.mit.delta.java.mdd.MddHandle;
+import hu.bme.mit.theta.analysis.algorithm.mdd.ansd.AbstractNextStateDescriptor;
+import hu.bme.mit.theta.analysis.algorithm.mdd.ansd.StateSpaceInfo;
+import java.util.ArrayList;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Constrained next-state descriptor: restricts the image of a wrapped relation to the states of a
+ * {@code constraint} set, descending the constraint node in lockstep with the relation, level by
+ * level. This is the "constrained saturation" hook used for CTL EU: wrapping the reversed
+ * transition relation with the constraint {@code phi ∪ psi} lets the unmodified {@link
+ * hu.bme.mit.theta.analysis.algorithm.mdd.fixedpoint.GeneralizedSaturationProvider} compute the
+ * least fixed point {@code mu Z. psi | (phi & pre(Z))} in a single call.
+ *
+ * <p>Modeled on {@link OnTheFlyReachabilityNextStateDescriptor}, with two essential differences:
+ *
+ * <ul>
+ *   <li>The constraint is part of the relation's meaning, so it is included in {@link #equals}/
+ *       {@link #hashCode} (otherwise distinct constraints collide in the saturation cache).
+ *   <li>Pruning is by <b>key absence</b>: the diagonal / off-diagonal maps are trimmed to the
+ *       constraint's key set, so a step into a state outside the constraint simply does not appear.
+ *       This satisfies two joint requirements of the (unmodified) saturation engine that the naive
+ *       approach violates: {@code satFire} asserts off-diagonal <i>values</i> are never {@code
+ *       terminalEmpty} (so we must not map a pruned key to {@code terminalEmpty}), and {@code
+ *       relProd} assumes every branch it descends reaches a terminal with {@code evaluate() ==
+ *       true} (so we must not let a pruned branch be descended at all — it would hit a terminal
+ *       whose constraint slice is zero). Dropping the key entirely avoids both.
+ * </ul>
+ */
+public final class AndNextStateDescriptor implements AbstractNextStateDescriptor {
+
+    private final AbstractNextStateDescriptor wrapped;
+
+    private final MddHandle constraint;
+
+    private AndNextStateDescriptor(AbstractNextStateDescriptor wrapped, MddHandle constraint) {
+        this.wrapped = wrapped;
+        this.constraint = Preconditions.checkNotNull(constraint);
+    }
+
+    public static AbstractNextStateDescriptor of(
+            AbstractNextStateDescriptor wrapped, MddHandle constraint) {
+        // Only short-circuit on an empty *relation*. Do NOT short-circuit on a zero constraint
+        // here:
+        // that would inject terminalEmpty into the off-diagonal map and trip saturation's
+        // assertion.
+        // A zero constraint is pruned later, in evaluate().
+        if (wrapped == AbstractNextStateDescriptor.terminalEmpty()) {
+            return AbstractNextStateDescriptor.terminalEmpty();
+        }
+        return new AndNextStateDescriptor(wrapped, constraint);
+    }
+
+    @Override
+    public IntObjMapView<AbstractNextStateDescriptor> getDiagonal(StateSpaceInfo localStateSpace) {
+        // Keep only keys present in the constraint (its non-zero children), then thread the
+        // corresponding constraint slice into each surviving continuation.
+        return new IntObjMapViews.Transforming<>(
+                wrapped.getDiagonal(localStateSpace).trim(constraint.keySet()),
+                (descriptor, key) -> {
+                    if (key == null) return descriptor;
+                    return AndNextStateDescriptor.of(descriptor, constraint.get(key));
+                });
+    }
+
+    @Override
+    public IntObjMapView<IntObjMapView<AbstractNextStateDescriptor>> getOffDiagonal(
+            StateSpaceInfo localStateSpace) {
+        // The constraint restricts the *target* (the new state reached), i.e. the inner key. The
+        // reversed relation's inner off-diagonal view supports only cursor()/get() (not trim), so
+        // we filter with a cursor that skips constraint-zero targets rather than trimming.
+        return new IntObjMapViews.Transforming<>(
+                wrapped.getOffDiagonal(localStateSpace), this::constrainInner);
+    }
+
+    private IntObjMapView<AbstractNextStateDescriptor> constrainInner(
+            IntObjMapView<AbstractNextStateDescriptor> inner) {
+        return new IntObjMapView<>() {
+            @Override
+            public IntObjCursor<? extends AbstractNextStateDescriptor> cursor() {
+                final IntObjCursor<? extends AbstractNextStateDescriptor> c = inner.cursor();
+                return new IntObjCursor<>() {
+                    @Override
+                    public int key() {
+                        return c.key();
+                    }
+
+                    @Override
+                    public AbstractNextStateDescriptor value() {
+                        return AndNextStateDescriptor.of(c.value(), constraint.get(c.key()));
+                    }
+
+                    @Override
+                    public boolean moveNext() {
+                        while (c.moveNext()) {
+                            if (!constraint.get(c.key()).isTerminalZero()) return true;
+                        }
+                        return false;
+                    }
+                };
+            }
+
+            @Override
+            public AbstractNextStateDescriptor get(int key) {
+                final MddHandle childConstraint = constraint.get(key);
+                if (childConstraint.isTerminalZero())
+                    return AbstractNextStateDescriptor.terminalEmpty();
+                return AndNextStateDescriptor.of(inner.get(key), childConstraint);
+            }
+
+            @Override
+            public boolean isEmpty() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean isProcedural() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean containsKey(int key) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public AbstractNextStateDescriptor defaultValue() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public int size() {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    @Override
+    public Optional<Iterable<AbstractNextStateDescriptor>> split() {
+        return wrapped.split()
+                .map(
+                        iterable -> {
+                            var list = new ArrayList<AbstractNextStateDescriptor>();
+                            iterable.forEach(
+                                    it -> list.add(new AndNextStateDescriptor(it, constraint)));
+                            return list;
+                        });
+    }
+
+    @Override
+    public boolean isLocallyIdentity(StateSpaceInfo stateSpaceInfo) {
+        return wrapped.isLocallyIdentity(stateSpaceInfo);
+    }
+
+    @Override
+    public boolean evaluate() {
+        // The relation accepts iff the wrapped relation accepts AND the fully-descended state lies
+        // in the constraint set (its terminal slice is non-zero).
+        return wrapped.evaluate() && !constraint.isTerminalZero();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AndNextStateDescriptor that = (AndNextStateDescriptor) o;
+        return Objects.equals(wrapped, that.wrapped) && Objects.equals(constraint, that.constraint);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(wrapped, constraint);
+    }
+
+    @Override
+    public String toString() {
+        return "And(" + wrapped + ", " + constraint + ")";
+    }
+}

--- a/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/mdd/ctl/CtlExpr.kt
+++ b/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/mdd/ctl/CtlExpr.kt
@@ -1,0 +1,69 @@
+/*
+ *  Copyright 2026 Budapest University of Technology and Economics
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package hu.bme.mit.theta.analysis.algorithm.mdd.ctl
+
+import hu.bme.mit.theta.core.type.Expr
+import hu.bme.mit.theta.core.type.booltype.BoolType
+
+/**
+ * Abstract syntax of CTL formulas evaluated by [MddCtlChecker].
+ *
+ * EX, EU and EG are the primitives; every other operator desugars to these plus boolean combinators
+ * (see [MddCtlChecker.eval]). The sealed hierarchy makes the evaluator's dispatch exhaustive.
+ */
+sealed interface CtlExpr {
+
+  // --- atomic ---------------------------------------------------------------------------------
+
+  /** A state predicate, lifted to an MDD node during evaluation. */
+  data class Atom(val expr: Expr<BoolType>) : CtlExpr
+
+  /**
+   * Structural "all (reachable) states" — the semantic universe. Deliberately not `Atom(True())`:
+   * it avoids building a solver-backed expression node just to denote the reachable state space.
+   */
+  data object Top : CtlExpr
+
+  // --- boolean --------------------------------------------------------------------------------
+
+  data class Not(val op: CtlExpr) : CtlExpr
+
+  data class And(val l: CtlExpr, val r: CtlExpr) : CtlExpr
+
+  data class Or(val l: CtlExpr, val r: CtlExpr) : CtlExpr
+
+  // --- primitives -----------------------------------------------------------------------------
+
+  data class EX(val op: CtlExpr) : CtlExpr
+
+  /** `E[l U r]`. */
+  data class EU(val l: CtlExpr, val r: CtlExpr) : CtlExpr
+
+  data class EG(val op: CtlExpr) : CtlExpr
+
+  // --- derived (desugar to primitives, no dedicated providers) --------------------------------
+
+  data class EF(val op: CtlExpr) : CtlExpr // = EU(Top, op)
+
+  data class AX(val op: CtlExpr) : CtlExpr // = !EX !op
+
+  data class AG(val op: CtlExpr) : CtlExpr // = !EF !op
+
+  data class AF(val op: CtlExpr) : CtlExpr // = !EG !op
+
+  /** `A[l U r]` = !(E[!r U (!l & !r)] | EG !r). */
+  data class AU(val l: CtlExpr, val r: CtlExpr) : CtlExpr
+}

--- a/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/mdd/ctl/CtlExpr.kt
+++ b/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/mdd/ctl/CtlExpr.kt
@@ -18,34 +18,20 @@ package hu.bme.mit.theta.analysis.algorithm.mdd.ctl
 import hu.bme.mit.theta.core.type.Expr
 import hu.bme.mit.theta.core.type.booltype.BoolType
 
-/**
- * Abstract syntax of CTL formulas evaluated by [MddCtlChecker].
- *
- * EX, EU and EG are the primitives; every other operator desugars to these plus boolean combinators
- * (see [MddCtlChecker.eval]). The sealed hierarchy makes the evaluator's dispatch exhaustive.
- */
+/** CTL formulas evaluated by [MddCtlChecker]. EX, EU and EG are the primitives. */
 sealed interface CtlExpr {
 
-  // --- atomic ---------------------------------------------------------------------------------
-
-  /** A state predicate, lifted to an MDD node during evaluation. */
+  /** A state predicate. */
   data class Atom(val expr: Expr<BoolType>) : CtlExpr
 
-  /**
-   * Structural "all (reachable) states" — the semantic universe. Deliberately not `Atom(True())`:
-   * it avoids building a solver-backed expression node just to denote the reachable state space.
-   */
+  /** All reachable states (avoids building a solver-backed node just for `true`). */
   data object Top : CtlExpr
-
-  // --- boolean --------------------------------------------------------------------------------
 
   data class Not(val op: CtlExpr) : CtlExpr
 
   data class And(val l: CtlExpr, val r: CtlExpr) : CtlExpr
 
   data class Or(val l: CtlExpr, val r: CtlExpr) : CtlExpr
-
-  // --- primitives -----------------------------------------------------------------------------
 
   data class EX(val op: CtlExpr) : CtlExpr
 
@@ -54,9 +40,7 @@ sealed interface CtlExpr {
 
   data class EG(val op: CtlExpr) : CtlExpr
 
-  // --- derived (desugar to primitives, no dedicated providers) --------------------------------
-
-  data class EF(val op: CtlExpr) : CtlExpr // = EU(Top, op)
+  data class EF(val op: CtlExpr) : CtlExpr // = E[Top U op]
 
   data class AX(val op: CtlExpr) : CtlExpr // = !EX !op
 

--- a/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/mdd/ctl/MddCtlChecker.kt
+++ b/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/mdd/ctl/MddCtlChecker.kt
@@ -1,0 +1,306 @@
+/*
+ *  Copyright 2026 Budapest University of Technology and Economics
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package hu.bme.mit.theta.analysis.algorithm.mdd.ctl
+
+import com.google.common.base.Preconditions
+import hu.bme.mit.delta.java.mdd.JavaMddFactory
+import hu.bme.mit.delta.java.mdd.MddHandle
+import hu.bme.mit.delta.java.mdd.MddVariableHandle
+import hu.bme.mit.delta.mdd.MddInterpreter
+import hu.bme.mit.delta.mdd.MddVariableDescriptor
+import hu.bme.mit.theta.analysis.algorithm.bounded.MonolithicExpr
+import hu.bme.mit.theta.analysis.algorithm.bounded.orderVars
+import hu.bme.mit.theta.analysis.algorithm.mdd.ansd.AbstractNextStateDescriptor
+import hu.bme.mit.theta.analysis.algorithm.mdd.ansd.impl.AndNextStateDescriptor
+import hu.bme.mit.theta.analysis.algorithm.mdd.ansd.impl.MddNodeInitializer
+import hu.bme.mit.theta.analysis.algorithm.mdd.ansd.impl.MddNodeNextStateDescriptor
+import hu.bme.mit.theta.analysis.algorithm.mdd.ansd.impl.OrNextStateDescriptor
+import hu.bme.mit.theta.analysis.algorithm.mdd.ansd.impl.ReverseNextStateDescriptor
+import hu.bme.mit.theta.analysis.algorithm.mdd.expressionnode.ExprLatticeDefinition
+import hu.bme.mit.theta.analysis.algorithm.mdd.expressionnode.MddExplicitRepresentationExtractor
+import hu.bme.mit.theta.analysis.algorithm.mdd.expressionnode.MddExpressionRepresentation
+import hu.bme.mit.theta.analysis.algorithm.mdd.expressionnode.MddExpressionTemplate
+import hu.bme.mit.theta.analysis.algorithm.mdd.fixedpoint.GeneralizedSaturationProvider
+import hu.bme.mit.theta.analysis.algorithm.mdd.fixedpoint.SingleStepProvider
+import hu.bme.mit.theta.common.collection.CollectionUtil
+import hu.bme.mit.theta.common.logging.Logger
+import hu.bme.mit.theta.core.decl.Decl
+import hu.bme.mit.theta.core.decl.VarDecl
+import hu.bme.mit.theta.core.type.Expr
+import hu.bme.mit.theta.core.type.abstracttype.AbstractExprs.Eq
+import hu.bme.mit.theta.core.type.booltype.BoolType
+import hu.bme.mit.theta.core.type.booltype.SmartBoolExprs.And
+import hu.bme.mit.theta.core.utils.PathUtils
+import hu.bme.mit.theta.core.utils.indexings.VarIndexingFactory
+import hu.bme.mit.theta.solver.SolverPool
+
+/**
+ * Symbolic CTL model checker over the MDD/saturation backend.
+ *
+ * The construction follows Zhao & Ciardo, *Symbolic CTL Model Checking of Asynchronous Systems
+ * Using Constrained Saturation* (ATVA 2009). EX, EU and EG are the primitives; the remaining
+ * operators desugar to these (see [eval]).
+ *
+ * Each primitive uses the machinery dictated by its fixed-point character:
+ * * **EX** — a single backward relational-product step over the reversed relation.
+ * * **EU** — a least fixed point. Either a single *constrained backward saturation* call (the
+ *   reversed relation wrapped in an [AndNextStateDescriptor] carrying the constraint phi | psi), or
+ *   the textbook lfp loop over single backward steps — selected by [EuStrategy]. Both yield the
+ *   same set.
+ * * **EG** — the traditional gfp loop (`EGtrad`): repeatedly keep only states that still have a
+ *   successor in the working set, until stable. Saturation cannot compute a greatest fixed point.
+ *
+ * CTL is evaluated over the **reachable** state space, so `universe = stateSpace`. Atoms are
+ * clamped to the universe and negation is complement against the universe, which keeps `eval` ⊆
+ * universe for every node and makes the duality rewrites sound.
+ */
+class MddCtlChecker
+@JvmOverloads
+constructor(
+  private val monolithicExpr: MonolithicExpr,
+  private val solverPool: SolverPool,
+  private val logger: Logger,
+  private val variableOrdering: List<VarDecl<*>> = monolithicExpr.orderVars(),
+  private val lookAheadStrategy: MddExpressionRepresentation.MddToExprStrategy =
+    MddExpressionRepresentation.MddToExprStrategy.VARIABLE_LEVEL,
+  private val euStrategy: EuStrategy = EuStrategy.CONSTRAINED_SATURATION,
+) {
+
+  /** How `E[phi U psi]` is computed. Both yield the same set; they differ in performance. */
+  enum class EuStrategy {
+    /** Single constrained backward saturation call (Ciardo's EUconsSat). */
+    CONSTRAINED_SATURATION,
+    /**
+     * The textbook least-fixed-point loop `mu Z. psi | (phi & pre(Z))` over single backward steps.
+     */
+    FIXPOINT_LOOP,
+  }
+
+  private val stateSig: hu.bme.mit.delta.java.mdd.MddSignature
+  private val transSig: hu.bme.mit.delta.java.mdd.MddSignature
+  private val topVar: MddVariableHandle
+
+  /** The reachable state space; also the semantic universe for CTL evaluation. */
+  val stateSpace: MddHandle
+  /** Initial states, used by [isSatisfied]. */
+  val initNode: MddHandle
+
+  private val reversedNS: AbstractNextStateDescriptor
+
+  private val gsat: GeneralizedSaturationProvider
+  private val singleStepProvider: SingleStepProvider
+
+  private val memo = HashMap<CtlExpr, MddHandle>()
+
+  private val universe: MddHandle
+    get() = stateSpace
+
+  init {
+    MddExpressionRepresentation.setLookAheadStrategy(lookAheadStrategy)
+
+    val mddGraph = JavaMddFactory.getDefault().createMddGraph(ExprLatticeDefinition.forExpr())
+    val mddGraph2 = JavaMddFactory.getDefault().createMddGraph(ExprLatticeDefinition.forExpr())
+
+    val stateOrder = JavaMddFactory.getDefault().createMddVariableOrder(mddGraph)
+    val transOrder = JavaMddFactory.getDefault().createMddVariableOrder(mddGraph2)
+
+    variableOrdering.forEach {
+      Preconditions.checkArgument(
+        monolithicExpr.vars.contains(it),
+        "Variable ordering contains variable not present in vars List",
+      )
+    }
+    Preconditions.checkArgument(
+      variableOrdering.size == CollectionUtil.createSet(variableOrdering).size,
+      "Variable ordering contains duplicates",
+    )
+
+    val identityExprs = mutableListOf<Expr<BoolType>>()
+    for (v in variableOrdering.reversed()) {
+      val domainSize = 0
+
+      stateOrder.createOnTop(MddVariableDescriptor.create(v.getConstDecl(0), domainSize))
+
+      val index = monolithicExpr.transOffsetIndex[v]
+      if (index > 0) {
+        transOrder.createOnTop(
+          MddVariableDescriptor.create(
+            v.getConstDecl(monolithicExpr.transOffsetIndex[v]),
+            domainSize,
+          )
+        )
+      } else {
+        transOrder.createOnTop(MddVariableDescriptor.create(v.getConstDecl(1), domainSize))
+        identityExprs.add(Eq(v.getConstDecl(0).ref, v.getConstDecl(1).ref))
+      }
+      transOrder.createOnTop(MddVariableDescriptor.create(v.getConstDecl(0), domainSize))
+    }
+
+    stateSig = stateOrder.defaultSetSignature
+    transSig = transOrder.defaultSetSignature
+    topVar = stateSig.topVariableHandle
+
+    // Initial states.
+    val initExpr = PathUtils.unfold(monolithicExpr.initExpr, 0)
+    initNode = topVar.checkInNode(MddExpressionTemplate.of(initExpr, { it as Decl<*> }, solverPool))
+    logger.write(Logger.Level.INFO, "Created initial node\n")
+
+    // Forward transition relation.
+    val transNodes = mutableListOf<MddHandle>()
+    val descriptors = mutableListOf<AbstractNextStateDescriptor>()
+    for (expr in monolithicExpr.split) {
+      val transExpr =
+        And(PathUtils.unfold(expr, VarIndexingFactory.indexing(0)), And(identityExprs))
+      val transitionNode =
+        transSig.topVariableHandle.checkInNode(
+          MddExpressionTemplate.of(transExpr, { it as Decl<*> }, solverPool, true)
+        )
+      transNodes.add(transitionNode)
+      descriptors.add(MddNodeNextStateDescriptor.of(transitionNode))
+    }
+    val nextStates: AbstractNextStateDescriptor = OrNextStateDescriptor.create(descriptors)
+
+    // Reachable state space = semantic universe.
+    gsat = GeneralizedSaturationProvider(stateSig.variableOrder)
+    stateSpace = gsat.compute(MddNodeInitializer.of(initNode), nextStates, topVar)
+    logger.write(
+      Logger.Level.INFO,
+      "Calculated state space, size: ${MddInterpreter.calculateNonzeroCount(stateSpace)}\n",
+    )
+
+    // Reversed relation, built once and reused by every operator.
+    val reversedDescriptors = mutableListOf<AbstractNextStateDescriptor>()
+    for (transNode in transNodes) {
+      val explTrans =
+        MddExplicitRepresentationExtractor.transform(transNode, transSig.topVariableHandle)
+      reversedDescriptors.add(ReverseNextStateDescriptor.of(stateSpace, explTrans))
+    }
+    reversedNS = OrNextStateDescriptor.create(reversedDescriptors)
+
+    singleStepProvider = SingleStepProvider(stateSig.variableOrder)
+  }
+
+  /** Evaluates [expr] to the set of (reachable) states satisfying it. */
+  fun check(expr: CtlExpr): MddHandle = eval(expr)
+
+  /** True iff every initial state satisfies [expr] (i.e. `initNode ⊆ eval(expr)`). */
+  fun isSatisfied(expr: CtlExpr): Boolean {
+    val violating = initNode.minus(eval(expr)) as MddHandle
+    return MddInterpreter.calculateNonzeroCount(violating) == 0L
+  }
+
+  /**
+   * Backward image: states with at least one successor in [x] (one step over the reversed
+   * relation).
+   */
+  private fun pre(x: MddHandle): MddHandle =
+    singleStepProvider.compute(MddNodeInitializer.of(x), reversedNS, topVar)
+
+  /**
+   * `E[phi U psi]` by a single constrained backward saturation call (Ciardo's EUconsSat). Seed is
+   * [q] = psi; the reversed relation is constrained to phi | psi via [AndNextStateDescriptor], so
+   * saturation only grows the set through states still satisfying phi (or the seed psi). The
+   * constraint is phi | psi (not phi alone) so seed states outside phi are not pruned.
+   */
+  private fun euSaturation(p: MddHandle, q: MddHandle): MddHandle {
+    val constraint = p.union(q) as MddHandle
+    val saturated =
+      gsat.compute(
+        MddNodeInitializer.of(q),
+        AndNextStateDescriptor.of(reversedNS, constraint),
+        topVar,
+      )
+    return saturated.intersection(universe) as MddHandle
+  }
+
+  /**
+   * `E[phi U psi]` by the textbook lfp loop `mu Z. psi | (phi & pre(Z))` over single backward
+   * steps.
+   */
+  private fun euFixpointLoop(p: MddHandle, q: MddHandle): MddHandle {
+    var z = q
+    while (true) {
+      val next = q.union(p.intersection(pre(z))) as MddHandle
+      if (next.node === z.node) break
+      z = next
+    }
+    return z
+  }
+
+  private fun eval(phi: CtlExpr): MddHandle =
+    memo.getOrPut(phi) {
+      when (phi) {
+        // Atoms are the only leaf that introduces fresh states, so clamp to the universe here.
+        // This is what makes the ⊆ universe invariant hold everywhere else automatically.
+        is CtlExpr.Atom -> {
+          val node =
+            topVar.checkInNode(
+              MddExpressionTemplate.of(PathUtils.unfold(phi.expr, 0), { it as Decl<*> }, solverPool)
+            )
+          // The universe (explicit, bounded) must drive the intersection: a symbolic atom node has
+          // an unbounded keyset, so it can only ever be queried key-by-key, never enumerated.
+          universe.intersection(node) as MddHandle
+        }
+
+        // Structural top: the universe itself; no node construction, no solver call.
+        CtlExpr.Top -> universe
+
+        is CtlExpr.Not -> universe.minus(eval(phi.op)) as MddHandle
+        is CtlExpr.And -> eval(phi.l).intersection(eval(phi.r)) as MddHandle
+        is CtlExpr.Or -> eval(phi.l).union(eval(phi.r)) as MddHandle
+
+        // EX phi = pre(phi): a single backward step.
+        is CtlExpr.EX -> pre(eval(phi.op))
+
+        // E[phi U psi] = mu Z. psi | (phi & pre(Z)) — least fixed point. Two interchangeable
+        // implementations, selected by euStrategy (see euSaturation / euFixpointLoop).
+        is CtlExpr.EU -> {
+          val p = eval(phi.l)
+          val q = eval(phi.r)
+          when (euStrategy) {
+            EuStrategy.CONSTRAINED_SATURATION -> euSaturation(p, q)
+            EuStrategy.FIXPOINT_LOOP -> euFixpointLoop(p, q)
+          }
+        }
+
+        // EG phi = nu Z. phi & pre(Z) — the EGtrad gfp loop. Saturation cannot compute a gfp.
+        is CtlExpr.EG -> {
+          var x = eval(phi.op)
+          while (true) {
+            val next = x.intersection(pre(x)) as MddHandle
+            if (next.node === x.node) break // canonical MDD identity = fixed point reached
+            x = next
+          }
+          x
+        }
+
+        // Derived operators: rewrite into primitives and recurse. No dedicated providers.
+        is CtlExpr.EF -> eval(CtlExpr.EU(CtlExpr.Top, phi.op))
+        is CtlExpr.AX -> eval(CtlExpr.Not(CtlExpr.EX(CtlExpr.Not(phi.op))))
+        is CtlExpr.AG -> eval(CtlExpr.Not(CtlExpr.EF(CtlExpr.Not(phi.op))))
+        is CtlExpr.AF -> eval(CtlExpr.Not(CtlExpr.EG(CtlExpr.Not(phi.op))))
+        is CtlExpr.AU ->
+          eval(
+            CtlExpr.Not(
+              CtlExpr.Or(
+                CtlExpr.EU(CtlExpr.Not(phi.r), CtlExpr.And(CtlExpr.Not(phi.l), CtlExpr.Not(phi.r))),
+                CtlExpr.EG(CtlExpr.Not(phi.r)),
+              )
+            )
+          )
+      }
+    }
+}

--- a/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/mdd/ctl/MddCtlChecker.kt
+++ b/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/mdd/ctl/MddCtlChecker.kt
@@ -18,6 +18,7 @@ package hu.bme.mit.theta.analysis.algorithm.mdd.ctl
 import com.google.common.base.Preconditions
 import hu.bme.mit.delta.java.mdd.JavaMddFactory
 import hu.bme.mit.delta.java.mdd.MddHandle
+import hu.bme.mit.delta.java.mdd.MddSignature
 import hu.bme.mit.delta.java.mdd.MddVariableHandle
 import hu.bme.mit.delta.mdd.MddInterpreter
 import hu.bme.mit.delta.mdd.MddVariableDescriptor
@@ -48,24 +49,10 @@ import hu.bme.mit.theta.core.utils.indexings.VarIndexingFactory
 import hu.bme.mit.theta.solver.SolverPool
 
 /**
- * Symbolic CTL model checker over the MDD/saturation backend.
- *
- * The construction follows Zhao & Ciardo, *Symbolic CTL Model Checking of Asynchronous Systems
- * Using Constrained Saturation* (ATVA 2009). EX, EU and EG are the primitives; the remaining
- * operators desugar to these (see [eval]).
- *
- * Each primitive uses the machinery dictated by its fixed-point character:
- * * **EX** — a single backward relational-product step over the reversed relation.
- * * **EU** — a least fixed point. Either a single *constrained backward saturation* call (the
- *   reversed relation wrapped in an [AndNextStateDescriptor] carrying the constraint phi | psi), or
- *   the textbook lfp loop over single backward steps — selected by [EuStrategy]. Both yield the
- *   same set.
- * * **EG** — the traditional gfp loop (`EGtrad`): repeatedly keep only states that still have a
- *   successor in the working set, until stable. Saturation cannot compute a greatest fixed point.
- *
- * CTL is evaluated over the **reachable** state space, so `universe = stateSpace`. Atoms are
- * clamped to the universe and negation is complement against the universe, which keeps `eval` ⊆
- * universe for every node and makes the duality rewrites sound.
+ * Symbolic CTL model checker over the MDD/saturation backend, based on Zhao & Ciardo, *Symbolic CTL
+ * Model Checking of Asynchronous Systems Using Constrained Saturation* (ATVA 2009). EX, EU and EG
+ * are the primitives; the remaining operators are rewritten to these. Formulas are evaluated over
+ * the reachable state space, and negation is complement against it.
  */
 class MddCtlChecker
 @JvmOverloads
@@ -79,23 +66,20 @@ constructor(
   private val euStrategy: EuStrategy = EuStrategy.CONSTRAINED_SATURATION,
 ) {
 
-  /** How `E[phi U psi]` is computed. Both yield the same set; they differ in performance. */
+  /** How `E[phi U psi]` is computed. */
   enum class EuStrategy {
-    /** Single constrained backward saturation call (Ciardo's EUconsSat). */
+    /** A single constrained backward saturation call. */
     CONSTRAINED_SATURATION,
-    /**
-     * The textbook least-fixed-point loop `mu Z. psi | (phi & pre(Z))` over single backward steps.
-     */
+    /** The lfp loop `mu Z. psi | (phi & pre(Z))` over single backward steps. */
     FIXPOINT_LOOP,
   }
 
-  private val stateSig: hu.bme.mit.delta.java.mdd.MddSignature
-  private val transSig: hu.bme.mit.delta.java.mdd.MddSignature
+  private val stateSig: MddSignature
+  private val transSig: MddSignature
   private val topVar: MddVariableHandle
 
-  /** The reachable state space; also the semantic universe for CTL evaluation. */
+  /** The reachable state space. */
   val stateSpace: MddHandle
-  /** Initial states, used by [isSatisfied]. */
   val initNode: MddHandle
 
   private val reversedNS: AbstractNextStateDescriptor
@@ -136,12 +120,7 @@ constructor(
 
       val index = monolithicExpr.transOffsetIndex[v]
       if (index > 0) {
-        transOrder.createOnTop(
-          MddVariableDescriptor.create(
-            v.getConstDecl(monolithicExpr.transOffsetIndex[v]),
-            domainSize,
-          )
-        )
+        transOrder.createOnTop(MddVariableDescriptor.create(v.getConstDecl(index), domainSize))
       } else {
         transOrder.createOnTop(MddVariableDescriptor.create(v.getConstDecl(1), domainSize))
         identityExprs.add(Eq(v.getConstDecl(0).ref, v.getConstDecl(1).ref))
@@ -153,12 +132,10 @@ constructor(
     transSig = transOrder.defaultSetSignature
     topVar = stateSig.topVariableHandle
 
-    // Initial states.
     val initExpr = PathUtils.unfold(monolithicExpr.initExpr, 0)
     initNode = topVar.checkInNode(MddExpressionTemplate.of(initExpr, { it as Decl<*> }, solverPool))
     logger.write(Logger.Level.INFO, "Created initial node\n")
 
-    // Forward transition relation.
     val transNodes = mutableListOf<MddHandle>()
     val descriptors = mutableListOf<AbstractNextStateDescriptor>()
     for (expr in monolithicExpr.split) {
@@ -173,7 +150,6 @@ constructor(
     }
     val nextStates: AbstractNextStateDescriptor = OrNextStateDescriptor.create(descriptors)
 
-    // Reachable state space = semantic universe.
     gsat = GeneralizedSaturationProvider(stateSig.variableOrder)
     stateSpace = gsat.compute(MddNodeInitializer.of(initNode), nextStates, topVar)
     logger.write(
@@ -181,7 +157,6 @@ constructor(
       "Calculated state space, size: ${MddInterpreter.calculateNonzeroCount(stateSpace)}\n",
     )
 
-    // Reversed relation, built once and reused by every operator.
     val reversedDescriptors = mutableListOf<AbstractNextStateDescriptor>()
     for (transNode in transNodes) {
       val explTrans =
@@ -196,24 +171,21 @@ constructor(
   /** Evaluates [expr] to the set of (reachable) states satisfying it. */
   fun check(expr: CtlExpr): MddHandle = eval(expr)
 
-  /** True iff every initial state satisfies [expr] (i.e. `initNode ⊆ eval(expr)`). */
+  /** True iff every initial state satisfies [expr]. */
   fun isSatisfied(expr: CtlExpr): Boolean {
-    val violating = initNode.minus(eval(expr)) as MddHandle
+    // the symbolic initNode cannot drive set operations, so instead of subtracting from it, it is
+    // intersected with the explicit complement (which queries it key-by-key only)
+    val violating = eval(CtlExpr.Not(expr)).intersection(initNode) as MddHandle
     return MddInterpreter.calculateNonzeroCount(violating) == 0L
   }
 
-  /**
-   * Backward image: states with at least one successor in [x] (one step over the reversed
-   * relation).
-   */
+  /** States with at least one successor in [x]. */
   private fun pre(x: MddHandle): MddHandle =
     singleStepProvider.compute(MddNodeInitializer.of(x), reversedNS, topVar)
 
   /**
-   * `E[phi U psi]` by a single constrained backward saturation call (Ciardo's EUconsSat). Seed is
-   * [q] = psi; the reversed relation is constrained to phi | psi via [AndNextStateDescriptor], so
-   * saturation only grows the set through states still satisfying phi (or the seed psi). The
-   * constraint is phi | psi (not phi alone) so seed states outside phi are not pruned.
+   * `E[phi U psi]` as a single constrained backward saturation call. The constraint is phi | psi
+   * (not phi alone) so that seed states outside phi are not pruned.
    */
   private fun euSaturation(p: MddHandle, q: MddHandle): MddHandle {
     val constraint = p.union(q) as MddHandle
@@ -226,10 +198,7 @@ constructor(
     return saturated.intersection(universe) as MddHandle
   }
 
-  /**
-   * `E[phi U psi]` by the textbook lfp loop `mu Z. psi | (phi & pre(Z))` over single backward
-   * steps.
-   */
+  /** `E[phi U psi]` by the lfp loop `mu Z. psi | (phi & pre(Z))`. */
   private fun euFixpointLoop(p: MddHandle, q: MddHandle): MddHandle {
     var z = q
     while (true) {
@@ -243,30 +212,24 @@ constructor(
   private fun eval(phi: CtlExpr): MddHandle =
     memo.getOrPut(phi) {
       when (phi) {
-        // Atoms are the only leaf that introduces fresh states, so clamp to the universe here.
-        // This is what makes the ⊆ universe invariant hold everywhere else automatically.
         is CtlExpr.Atom -> {
           val node =
             topVar.checkInNode(
               MddExpressionTemplate.of(PathUtils.unfold(phi.expr, 0), { it as Decl<*> }, solverPool)
             )
-          // The universe (explicit, bounded) must drive the intersection: a symbolic atom node has
-          // an unbounded keyset, so it can only ever be queried key-by-key, never enumerated.
+          // the explicit universe must drive the intersection: the symbolic atom node has an
+          // unbounded keyset and can only be queried key-by-key
           universe.intersection(node) as MddHandle
         }
 
-        // Structural top: the universe itself; no node construction, no solver call.
         CtlExpr.Top -> universe
 
         is CtlExpr.Not -> universe.minus(eval(phi.op)) as MddHandle
         is CtlExpr.And -> eval(phi.l).intersection(eval(phi.r)) as MddHandle
         is CtlExpr.Or -> eval(phi.l).union(eval(phi.r)) as MddHandle
 
-        // EX phi = pre(phi): a single backward step.
         is CtlExpr.EX -> pre(eval(phi.op))
 
-        // E[phi U psi] = mu Z. psi | (phi & pre(Z)) — least fixed point. Two interchangeable
-        // implementations, selected by euStrategy (see euSaturation / euFixpointLoop).
         is CtlExpr.EU -> {
           val p = eval(phi.l)
           val q = eval(phi.r)
@@ -276,18 +239,17 @@ constructor(
           }
         }
 
-        // EG phi = nu Z. phi & pre(Z) — the EGtrad gfp loop. Saturation cannot compute a gfp.
+        // EG phi = nu Z. phi & pre(Z); saturation cannot compute greatest fixed points
         is CtlExpr.EG -> {
           var x = eval(phi.op)
           while (true) {
             val next = x.intersection(pre(x)) as MddHandle
-            if (next.node === x.node) break // canonical MDD identity = fixed point reached
+            if (next.node === x.node) break
             x = next
           }
           x
         }
 
-        // Derived operators: rewrite into primitives and recurse. No dedicated providers.
         is CtlExpr.EF -> eval(CtlExpr.EU(CtlExpr.Top, phi.op))
         is CtlExpr.AX -> eval(CtlExpr.Not(CtlExpr.EX(CtlExpr.Not(phi.op))))
         is CtlExpr.AG -> eval(CtlExpr.Not(CtlExpr.EF(CtlExpr.Not(phi.op))))

--- a/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/mdd/ctl/MddCtlChecker.kt
+++ b/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/mdd/ctl/MddCtlChecker.kt
@@ -34,8 +34,9 @@ import hu.bme.mit.theta.analysis.algorithm.mdd.expressionnode.ExprLatticeDefinit
 import hu.bme.mit.theta.analysis.algorithm.mdd.expressionnode.MddExplicitRepresentationExtractor
 import hu.bme.mit.theta.analysis.algorithm.mdd.expressionnode.MddExpressionRepresentation
 import hu.bme.mit.theta.analysis.algorithm.mdd.expressionnode.MddExpressionTemplate
-import hu.bme.mit.theta.analysis.algorithm.mdd.fixedpoint.GeneralizedSaturationProvider
+import hu.bme.mit.theta.analysis.algorithm.mdd.fixedpoint.IterationStrategy
 import hu.bme.mit.theta.analysis.algorithm.mdd.fixedpoint.SingleStepProvider
+import hu.bme.mit.theta.analysis.algorithm.mdd.fixedpoint.StateSpaceEnumerationProvider
 import hu.bme.mit.theta.common.collection.CollectionUtil
 import hu.bme.mit.theta.common.logging.Logger
 import hu.bme.mit.theta.core.decl.Decl
@@ -60,6 +61,7 @@ constructor(
   private val monolithicExpr: MonolithicExpr,
   private val solverPool: SolverPool,
   private val logger: Logger,
+  private val iterationStrategy: IterationStrategy = IterationStrategy.GSAT,
   private val variableOrdering: List<VarDecl<*>> = monolithicExpr.orderVars(),
   private val lookAheadStrategy: MddExpressionRepresentation.MddToExprStrategy =
     MddExpressionRepresentation.MddToExprStrategy.VARIABLE_LEVEL,
@@ -84,7 +86,7 @@ constructor(
 
   private val reversedNS: AbstractNextStateDescriptor
 
-  private val gsat: GeneralizedSaturationProvider
+  private val stateSpaceProvider: StateSpaceEnumerationProvider
   private val singleStepProvider: SingleStepProvider
 
   private val memo = HashMap<CtlExpr, MddHandle>()
@@ -150,8 +152,8 @@ constructor(
     }
     val nextStates: AbstractNextStateDescriptor = OrNextStateDescriptor.create(descriptors)
 
-    gsat = GeneralizedSaturationProvider(stateSig.variableOrder)
-    stateSpace = gsat.compute(MddNodeInitializer.of(initNode), nextStates, topVar)
+    stateSpaceProvider = iterationStrategy.createProvider(stateSig.variableOrder)
+    stateSpace = stateSpaceProvider.compute(MddNodeInitializer.of(initNode), nextStates, topVar)
     logger.write(
       Logger.Level.INFO,
       "Calculated state space, size: ${MddInterpreter.calculateNonzeroCount(stateSpace)}\n",
@@ -184,13 +186,13 @@ constructor(
     singleStepProvider.compute(MddNodeInitializer.of(x), reversedNS, topVar)
 
   /**
-   * `E[phi U psi]` as a single constrained backward saturation call. The constraint is phi | psi
+   * `E[phi U psi]` as a single constrained backward fixed-point call. The constraint is phi | psi
    * (not phi alone) so that seed states outside phi are not pruned.
    */
   private fun euSaturation(p: MddHandle, q: MddHandle): MddHandle {
     val constraint = p.union(q) as MddHandle
     val saturated =
-      gsat.compute(
+      stateSpaceProvider.compute(
         MddNodeInitializer.of(q),
         AndNextStateDescriptor.of(reversedNS, constraint),
         topVar,

--- a/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/mdd/ctl/MddCtlChecker.kt
+++ b/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/mdd/ctl/MddCtlChecker.kt
@@ -224,7 +224,7 @@ constructor(
           universe.intersection(node) as MddHandle
         }
 
-        CtlExpr.Top -> universe
+        is CtlExpr.Top -> universe
 
         is CtlExpr.Not -> universe.minus(eval(phi.op)) as MddHandle
         is CtlExpr.And -> eval(phi.l).intersection(eval(phi.r)) as MddHandle

--- a/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/mdd/fixedpoint/IterationStrategy.kt
+++ b/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/mdd/fixedpoint/IterationStrategy.kt
@@ -1,0 +1,32 @@
+/*
+ *  Copyright 2026 Budapest University of Technology and Economics
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package hu.bme.mit.theta.analysis.algorithm.mdd.fixedpoint
+
+import hu.bme.mit.delta.java.mdd.MddVariableOrder
+
+/** The state space enumeration algorithm of the MDD-based checkers. */
+enum class IterationStrategy {
+  BFS,
+  SAT,
+  GSAT;
+
+  fun createProvider(variableOrder: MddVariableOrder): StateSpaceEnumerationProvider =
+    when (this) {
+      BFS -> BfsProvider(variableOrder)
+      SAT -> SimpleSaturationProvider(variableOrder)
+      GSAT -> GeneralizedSaturationProvider(variableOrder)
+    }
+}

--- a/subprojects/common/analysis/src/test/java/hu/bme/mit/theta/analysis/algorithm/mdd/MddCheckerTest.java
+++ b/subprojects/common/analysis/src/test/java/hu/bme/mit/theta/analysis/algorithm/mdd/MddCheckerTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2025 Budapest University of Technology and Economics
+ *  Copyright 2026 Budapest University of Technology and Economics
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/subprojects/common/analysis/src/test/java/hu/bme/mit/theta/analysis/algorithm/mdd/MddCheckerTest.java
+++ b/subprojects/common/analysis/src/test/java/hu/bme/mit/theta/analysis/algorithm/mdd/MddCheckerTest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import hu.bme.mit.theta.analysis.Trace;
 import hu.bme.mit.theta.analysis.algorithm.SafetyResult;
 import hu.bme.mit.theta.analysis.algorithm.bounded.MonolithicExpr;
+import hu.bme.mit.theta.analysis.algorithm.mdd.fixedpoint.IterationStrategy;
 import hu.bme.mit.theta.analysis.expl.ExplState;
 import hu.bme.mit.theta.analysis.expr.ExprAction;
 import hu.bme.mit.theta.common.logging.ConsoleLogger;
@@ -147,7 +148,7 @@ public class MddCheckerTest {
             Long stateSpaceSize)
             throws Exception {
         initMddCheckerTest(initExpr, tranExpr, propExpr, safe, stateSpaceSize);
-        testWithIterationStrategy(MddChecker.IterationStrategy.BFS);
+        testWithIterationStrategy(IterationStrategy.BFS);
     }
 
     @MethodSource("data")
@@ -160,7 +161,7 @@ public class MddCheckerTest {
             Long stateSpaceSize)
             throws Exception {
         initMddCheckerTest(initExpr, tranExpr, propExpr, safe, stateSpaceSize);
-        testWithIterationStrategy(MddChecker.IterationStrategy.SAT);
+        testWithIterationStrategy(IterationStrategy.SAT);
     }
 
     @MethodSource("data")
@@ -173,11 +174,10 @@ public class MddCheckerTest {
             Long stateSpaceSize)
             throws Exception {
         initMddCheckerTest(initExpr, tranExpr, propExpr, safe, stateSpaceSize);
-        testWithIterationStrategy(MddChecker.IterationStrategy.GSAT);
+        testWithIterationStrategy(IterationStrategy.GSAT);
     }
 
-    public void testWithIterationStrategy(MddChecker.IterationStrategy iterationStrategy)
-            throws Exception {
+    public void testWithIterationStrategy(IterationStrategy iterationStrategy) throws Exception {
 
         final Logger logger = new ConsoleLogger(Logger.Level.SUBSTEP);
 

--- a/subprojects/common/analysis/src/test/java/hu/bme/mit/theta/analysis/algorithm/mdd/ctl/MddCtlCheckerTest.kt
+++ b/subprojects/common/analysis/src/test/java/hu/bme/mit/theta/analysis/algorithm/mdd/ctl/MddCtlCheckerTest.kt
@@ -37,12 +37,7 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
-/**
- * Validates [MddCtlChecker] on a small counter model:
- *
- * x in {0,1,2,3}, init x=0, transition x' = x+1 while x<3 and a self-loop x'=x at x=3. The
- * reachable state space is {0,1,2,3}; state 3 carries an infinite path via its self-loop.
- */
+/** Counter model: x in {0,1,2,3}, init x=0, x' = x+1 while x<3, self-loop at x=3. */
 class MddCtlCheckerTest {
 
   private val x = Decls.Var("x", IntType.getInstance())
@@ -61,7 +56,6 @@ class MddCtlCheckerTest {
     block: (MddCtlChecker) -> T,
   ): T {
     val init = Eq(x.ref, Int(0))
-    // (x < 3 & x' = x+1) | (x = 3 & x' = x)  — total over the reachable states
     val trans =
       Or(
         And(Lt(x.ref, Int(3)), Eq(Prime(x.ref), Add(x.ref, Int(1)))),
@@ -82,25 +76,23 @@ class MddCtlCheckerTest {
   @Test
   fun stateSpaceHasFourStates() = withChecker { c ->
     assertEquals(4L, MddInterpreter.calculateNonzeroCount(c.stateSpace))
-    // atoms are clamped to the reachable universe
     assertEquals(1L, count(c, xIs3))
     assertEquals(3L, count(c, xLt3))
   }
 
   @Test
   fun exactSetSizes() = withChecker { c ->
-    // EX(x=1): only state 0 has a successor where x=1
+    // only state 0 has a successor where x=1
     assertEquals(1L, count(c, CtlExpr.EX(xIs1)))
-    // EF(x=3): every state reaches 3
+    // every state reaches 3
     assertEquals(4L, count(c, CtlExpr.EF(xIs3)))
-    // EG(x=3): the only x=3 cycle is the self-loop at 3
+    // the only x=3 cycle is the self-loop at 3
     assertEquals(1L, count(c, CtlExpr.EG(xIs3)))
-    // EG(true): every state has an infinite path (all eventually reach the self-loop)
+    // every state has an infinite path
     assertEquals(4L, count(c, CtlExpr.EG(CtlExpr.Top)))
-    // E[x<3 U x=3]: 0,1,2 stay <3 and reach 3; 3 is already there
+    // 0,1,2 stay <3 and reach 3; 3 is already there
     assertEquals(4L, count(c, CtlExpr.EU(xLt3, xIs3)))
-    // E[x<2 U x=3]: only state 3 qualifies (psi already holds there); 0/1 cannot reach 3 without
-    // passing through x=2 which is not <2
+    // only state 3 qualifies; 0/1 cannot reach 3 without passing through x=2
     assertEquals(1L, count(c, CtlExpr.EU(xLt2, xIs3)))
   }
 
@@ -109,16 +101,15 @@ class MddCtlCheckerTest {
     assertTrue(c.isSatisfied(CtlExpr.EF(xIs3)))
     assertTrue(c.isSatisfied(CtlExpr.EX(xIs1)))
     assertFalse(c.isSatisfied(CtlExpr.EX(xIs2)))
-    assertTrue(c.isSatisfied(CtlExpr.AF(xIs3))) // all paths eventually reach 3
-    assertFalse(c.isSatisfied(CtlExpr.EG(xIs3))) // 0 is not on a x=3 cycle
-    assertTrue(c.isSatisfied(CtlExpr.AG(xLt3.let { CtlExpr.Or(it, xIs3) }))) // x<=3 everywhere
-    assertFalse(c.isSatisfied(CtlExpr.AG(CtlExpr.Not(xIs2)))) // x=2 is reachable
-    assertFalse(c.isSatisfied(CtlExpr.AG(CtlExpr.EF(xIs0)))) // cannot return to 0 from 1,2,3
+    assertTrue(c.isSatisfied(CtlExpr.AF(xIs3)))
+    assertFalse(c.isSatisfied(CtlExpr.EG(xIs3)))
+    assertTrue(c.isSatisfied(CtlExpr.AG(xLt3.let { CtlExpr.Or(it, xIs3) })))
+    assertFalse(c.isSatisfied(CtlExpr.AG(CtlExpr.Not(xIs2))))
+    assertFalse(c.isSatisfied(CtlExpr.AG(CtlExpr.EF(xIs0))))
   }
 
   @Test
   fun euStrategiesAgree() {
-    // EU appears directly, via EF (= EU(Top, .)), and via the AU rewrite; all must match.
     val formulas =
       listOf(
         CtlExpr.EU(xLt3, xIs3),

--- a/subprojects/common/analysis/src/test/java/hu/bme/mit/theta/analysis/algorithm/mdd/ctl/MddCtlCheckerTest.kt
+++ b/subprojects/common/analysis/src/test/java/hu/bme/mit/theta/analysis/algorithm/mdd/ctl/MddCtlCheckerTest.kt
@@ -1,0 +1,152 @@
+/*
+ *  Copyright 2026 Budapest University of Technology and Economics
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package hu.bme.mit.theta.analysis.algorithm.mdd.ctl
+
+import hu.bme.mit.delta.mdd.MddInterpreter
+import hu.bme.mit.theta.analysis.algorithm.bounded.MonolithicExpr
+import hu.bme.mit.theta.common.logging.NullLogger
+import hu.bme.mit.theta.core.decl.Decls
+import hu.bme.mit.theta.core.type.Expr
+import hu.bme.mit.theta.core.type.abstracttype.AbstractExprs.Add
+import hu.bme.mit.theta.core.type.abstracttype.AbstractExprs.Eq
+import hu.bme.mit.theta.core.type.abstracttype.AbstractExprs.Lt
+import hu.bme.mit.theta.core.type.anytype.Exprs.Prime
+import hu.bme.mit.theta.core.type.booltype.BoolExprs.Or
+import hu.bme.mit.theta.core.type.booltype.BoolExprs.True
+import hu.bme.mit.theta.core.type.booltype.BoolType
+import hu.bme.mit.theta.core.type.booltype.SmartBoolExprs.And
+import hu.bme.mit.theta.core.type.inttype.IntExprs.Int
+import hu.bme.mit.theta.core.type.inttype.IntType
+import hu.bme.mit.theta.solver.SolverPool
+import hu.bme.mit.theta.solver.z3legacy.Z3LegacySolverFactory
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Validates [MddCtlChecker] on a small counter model:
+ *
+ * x in {0,1,2,3}, init x=0, transition x' = x+1 while x<3 and a self-loop x'=x at x=3. The
+ * reachable state space is {0,1,2,3}; state 3 carries an infinite path via its self-loop.
+ */
+class MddCtlCheckerTest {
+
+  private val x = Decls.Var("x", IntType.getInstance())
+
+  private fun atom(e: Expr<BoolType>): CtlExpr = CtlExpr.Atom(e)
+
+  private val xIs0 = atom(Eq(x.ref, Int(0)))
+  private val xIs1 = atom(Eq(x.ref, Int(1)))
+  private val xIs2 = atom(Eq(x.ref, Int(2)))
+  private val xIs3 = atom(Eq(x.ref, Int(3)))
+  private val xLt2 = atom(Lt(x.ref, Int(2)))
+  private val xLt3 = atom(Lt(x.ref, Int(3)))
+
+  private fun <T> withChecker(
+    euStrategy: MddCtlChecker.EuStrategy = MddCtlChecker.EuStrategy.CONSTRAINED_SATURATION,
+    block: (MddCtlChecker) -> T,
+  ): T {
+    val init = Eq(x.ref, Int(0))
+    // (x < 3 & x' = x+1) | (x = 3 & x' = x)  — total over the reachable states
+    val trans =
+      Or(
+        And(Lt(x.ref, Int(3)), Eq(Prime(x.ref), Add(x.ref, Int(1)))),
+        And(Eq(x.ref, Int(3)), Eq(Prime(x.ref), x.ref)),
+      )
+    val prop = True()
+    val monolithicExpr = MonolithicExpr(init, trans, prop)
+    SolverPool(Z3LegacySolverFactory.getInstance()).use { pool ->
+      return block(
+        MddCtlChecker(monolithicExpr, pool, NullLogger.getInstance(), euStrategy = euStrategy)
+      )
+    }
+  }
+
+  private fun count(c: MddCtlChecker, e: CtlExpr): Long =
+    MddInterpreter.calculateNonzeroCount(c.check(e))
+
+  @Test
+  fun stateSpaceHasFourStates() = withChecker { c ->
+    assertEquals(4L, MddInterpreter.calculateNonzeroCount(c.stateSpace))
+    // atoms are clamped to the reachable universe
+    assertEquals(1L, count(c, xIs3))
+    assertEquals(3L, count(c, xLt3))
+  }
+
+  @Test
+  fun exactSetSizes() = withChecker { c ->
+    // EX(x=1): only state 0 has a successor where x=1
+    assertEquals(1L, count(c, CtlExpr.EX(xIs1)))
+    // EF(x=3): every state reaches 3
+    assertEquals(4L, count(c, CtlExpr.EF(xIs3)))
+    // EG(x=3): the only x=3 cycle is the self-loop at 3
+    assertEquals(1L, count(c, CtlExpr.EG(xIs3)))
+    // EG(true): every state has an infinite path (all eventually reach the self-loop)
+    assertEquals(4L, count(c, CtlExpr.EG(CtlExpr.Top)))
+    // E[x<3 U x=3]: 0,1,2 stay <3 and reach 3; 3 is already there
+    assertEquals(4L, count(c, CtlExpr.EU(xLt3, xIs3)))
+    // E[x<2 U x=3]: only state 3 qualifies (psi already holds there); 0/1 cannot reach 3 without
+    // passing through x=2 which is not <2
+    assertEquals(1L, count(c, CtlExpr.EU(xLt2, xIs3)))
+  }
+
+  @Test
+  fun satisfactionAtInitialState() = withChecker { c ->
+    assertTrue(c.isSatisfied(CtlExpr.EF(xIs3)))
+    assertTrue(c.isSatisfied(CtlExpr.EX(xIs1)))
+    assertFalse(c.isSatisfied(CtlExpr.EX(xIs2)))
+    assertTrue(c.isSatisfied(CtlExpr.AF(xIs3))) // all paths eventually reach 3
+    assertFalse(c.isSatisfied(CtlExpr.EG(xIs3))) // 0 is not on a x=3 cycle
+    assertTrue(c.isSatisfied(CtlExpr.AG(xLt3.let { CtlExpr.Or(it, xIs3) }))) // x<=3 everywhere
+    assertFalse(c.isSatisfied(CtlExpr.AG(CtlExpr.Not(xIs2)))) // x=2 is reachable
+    assertFalse(c.isSatisfied(CtlExpr.AG(CtlExpr.EF(xIs0)))) // cannot return to 0 from 1,2,3
+  }
+
+  @Test
+  fun euStrategiesAgree() {
+    // EU appears directly, via EF (= EU(Top, .)), and via the AU rewrite; all must match.
+    val formulas =
+      listOf(
+        CtlExpr.EU(xLt3, xIs3),
+        CtlExpr.EU(xLt2, xIs3),
+        CtlExpr.EF(xIs3),
+        CtlExpr.AU(xLt3, xIs3),
+        CtlExpr.AG(CtlExpr.EF(xIs0)),
+      )
+    val saturation =
+      withChecker(MddCtlChecker.EuStrategy.CONSTRAINED_SATURATION) { c ->
+        formulas.map { count(c, it) }
+      }
+    val fixpointLoop =
+      withChecker(MddCtlChecker.EuStrategy.FIXPOINT_LOOP) { c -> formulas.map { count(c, it) } }
+    assertEquals(saturation, fixpointLoop)
+  }
+
+  @Test
+  fun dualitiesHoldAsSets() = withChecker { c ->
+    // AG p == !EF !p
+    val p = CtlExpr.Or(xLt3, xIs3)
+    assertEquals(c.check(CtlExpr.AG(p)).node, c.check(CtlExpr.Not(CtlExpr.EF(CtlExpr.Not(p)))).node)
+    // AF p == !EG !p
+    assertEquals(
+      c.check(CtlExpr.AF(xIs3)).node,
+      c.check(CtlExpr.Not(CtlExpr.EG(CtlExpr.Not(xIs3)))).node,
+    )
+    // EF p == E[Top U p]
+    assertEquals(c.check(CtlExpr.EF(xIs3)).node, c.check(CtlExpr.EU(CtlExpr.Top, xIs3)).node)
+  }
+}

--- a/subprojects/common/ctl/build.gradle.kts
+++ b/subprojects/common/ctl/build.gradle.kts
@@ -1,0 +1,29 @@
+/*
+ *  Copyright 2026 Budapest University of Technology and Economics
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+plugins {
+    id("java-common")
+    id("kotlin-common")
+    id("antlr-grammar")
+}
+
+dependencies {
+    implementation(project(":theta-common"))
+    implementation(project(":theta-core"))
+    api(project(":theta-analysis"))
+    testImplementation(files(rootDir.resolve(Deps.delta)))
+    testImplementation(project(":theta-solver"))
+    testImplementation(project(":theta-solver-z3-legacy"))
+}

--- a/subprojects/common/ctl/src/main/antlr/CtlDsl.g4
+++ b/subprojects/common/ctl/src/main/antlr/CtlDsl.g4
@@ -1,0 +1,124 @@
+/*
+ *  Copyright 2026 Budapest University of Technology and Economics
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+grammar CtlDsl;
+
+// ---------- Parser ----------
+//
+// Precedence, loosest to tightest: <-> , -> , | , & , unary (! EX EG EF AX AG AF),
+// the binary path quantifiers E[_ U _] / A[_ U _], then atoms / parentheses.
+// Each precedence level is its own rule (the standard layered technique), which keeps the
+// tree unambiguous and left-recursion free. Boolean combinators live at the CTL level; an
+// atom is a relational expression over arithmetic (as in the LTL grammar), so a conjunction
+// like `x >= 0 & x <= 9` is And(Atom(x>=0), Atom(x<=9)).
+
+model : iffExpr EOF ;
+
+iffExpr : ops+=implyExpr (IFF ops+=implyExpr)* ;
+
+implyExpr : ops+=orExpr (IMPLY ops+=orExpr)* ;
+
+orExpr : ops+=andExpr (OR ops+=andExpr)* ;
+
+andExpr : ops+=unaryExpr (AND ops+=unaryExpr)* ;
+
+unaryExpr
+    : NOT op=unaryExpr   # NotExpr
+    | EX op=unaryExpr    # ExExpr
+    | EF op=unaryExpr    # EfExpr
+    | EG op=unaryExpr    # EgExpr
+    | AX op=unaryExpr    # AxExpr
+    | AF op=unaryExpr    # AfExpr
+    | AG op=unaryExpr    # AgExpr
+    | quantExpr          # QuantPassthrough
+    ;
+
+quantExpr
+    : E LBRACK l=iffExpr UNTIL r=iffExpr RBRACK   # EuExpr
+    | A LBRACK l=iffExpr UNTIL r=iffExpr RBRACK   # AuExpr
+    | LPAREN iffExpr RPAREN                       # ParenCtlExpr
+    | atom                                        # AtomExpr
+    ;
+
+// An atom is an embedded state predicate: a relational expression over arithmetic, or a bare
+// boolean variable / literal.
+atom : relationExpr ;
+
+relationExpr : ops+=additiveExpr (oper=relationOp ops+=additiveExpr)? ;
+
+relationOp : EQ | NEQ | LT | GT | LEQ | GEQ ;
+
+additiveExpr : ops+=multiplicativeExpr (opers+=additiveOp ops+=multiplicativeExpr)* ;
+
+additiveOp : PLUS | MINUS ;
+
+multiplicativeExpr : ops+=primaryArith (opers+=multiplicativeOp ops+=primaryArith)* ;
+
+multiplicativeOp : MUL | DIV | MOD ;
+
+primaryArith
+    : value=INTLIT                # IntLitExpr
+    | value=BOOLLIT               # BoolLitExpr
+    | name=ID                     # VarExpr
+    | MINUS op=primaryArith       # NegArithExpr
+    | LPAREN additiveExpr RPAREN  # ParenArithExpr
+    ;
+
+// ---------- Lexer ----------
+//
+// Temporal / path keywords are declared before ID so they are not swallowed by it. They win
+// over ID only on an exact-length match (ANTLR prefers the longest match, then the earlier
+// rule), so `EXtra` still lexes as an identifier while `EX` is the operator. A variable named
+// literally EX/EF/EG/AX/AF/AG/E/A/U would clash with a keyword.
+
+EX     : 'EX' ;
+EF     : 'EF' ;
+EG     : 'EG' ;
+AX     : 'AX' ;
+AF     : 'AF' ;
+AG     : 'AG' ;
+E      : 'E' ;
+A      : 'A' ;
+UNTIL  : 'U' ;
+
+IFF    : '<->' | '<=>' ;
+IMPLY  : '->' | '=>' ;
+NOT    : '!' | 'not' | 'NOT' ;
+AND    : '&' | '&&' | 'and' | 'AND' ;
+OR     : '|' | '||' | 'or' | 'OR' ;
+
+NEQ    : '!=' | '/=' ;
+EQ     : '=' | '==' ;
+LEQ    : '<=' ;
+GEQ    : '>=' ;
+LT     : '<' ;
+GT     : '>' ;
+
+PLUS   : '+' ;
+MINUS  : '-' ;
+MUL    : '*' ;
+DIV    : '/' ;
+MOD    : '%' ;
+
+LPAREN : '(' ;
+RPAREN : ')' ;
+LBRACK : '[' ;
+RBRACK : ']' ;
+
+BOOLLIT : 'true' | 'false' ;
+INTLIT  : [0-9]+ ;
+ID      : [a-zA-Z_][a-zA-Z0-9_]* ;
+
+WS     : [ \t\r\n]+ -> skip ;

--- a/subprojects/common/ctl/src/main/antlr/CtlDsl.g4
+++ b/subprojects/common/ctl/src/main/antlr/CtlDsl.g4
@@ -15,14 +15,9 @@
  */
 grammar CtlDsl;
 
-// ---------- Parser ----------
-//
 // Precedence, loosest to tightest: <-> , -> , | , & , unary (! EX EG EF AX AG AF),
-// the binary path quantifiers E[_ U _] / A[_ U _], then atoms / parentheses.
-// Each precedence level is its own rule (the standard layered technique), which keeps the
-// tree unambiguous and left-recursion free. Boolean combinators live at the CTL level; an
-// atom is a relational expression over arithmetic (as in the LTL grammar), so a conjunction
-// like `x >= 0 & x <= 9` is And(Atom(x>=0), Atom(x<=9)).
+// E[_ U _] / A[_ U _], then atoms / parentheses. An atom is a relational expression over
+// arithmetic (as in the LTL grammar), so `x >= 0 & x <= 9` is And(Atom(x>=0), Atom(x<=9)).
 
 model : iffExpr EOF ;
 
@@ -52,8 +47,6 @@ quantExpr
     | atom                                        # AtomExpr
     ;
 
-// An atom is an embedded state predicate: a relational expression over arithmetic, or a bare
-// boolean variable / literal.
 atom : relationExpr ;
 
 relationExpr : ops+=additiveExpr (oper=relationOp ops+=additiveExpr)? ;
@@ -76,12 +69,8 @@ primaryArith
     | LPAREN additiveExpr RPAREN  # ParenArithExpr
     ;
 
-// ---------- Lexer ----------
-//
-// Temporal / path keywords are declared before ID so they are not swallowed by it. They win
-// over ID only on an exact-length match (ANTLR prefers the longest match, then the earlier
-// rule), so `EXtra` still lexes as an identifier while `EX` is the operator. A variable named
-// literally EX/EF/EG/AX/AF/AG/E/A/U would clash with a keyword.
+// Keywords are declared before ID but win only on an exact match (`EXtra` is an identifier);
+// a variable named literally EX/EF/EG/AX/AF/AG/E/A/U clashes with a keyword.
 
 EX     : 'EX' ;
 EF     : 'EF' ;

--- a/subprojects/common/ctl/src/main/kotlin/hu/bme/mit/theta/ctl/CtlExprVisitor.kt
+++ b/subprojects/common/ctl/src/main/kotlin/hu/bme/mit/theta/ctl/CtlExprVisitor.kt
@@ -38,21 +38,14 @@ import hu.bme.mit.theta.ctl.dsl.gen.CtlDslBaseVisitor
 import hu.bme.mit.theta.ctl.dsl.gen.CtlDslParser.*
 
 /**
- * Folds a `CtlDsl` parse tree into a [CtlExpr].
- *
- * The CTL boolean operators (`!`, `&`, `|`, `->`, `<->`) live at the formula level and become
- * [CtlExpr.Not]/[CtlExpr.And]/[CtlExpr.Or] (with `->`/`<->` desugared). An atom is a relational
- * expression over arithmetic (or a bare boolean variable/literal); it is turned into an
- * `Expr<BoolType>` with the supplied [vars] symbol table and wrapped in [CtlExpr.Atom].
- *
- * The visitor is pure — it produces the AST only; all MDD/semantic work happens later in the
- * checker.
+ * Folds a `CtlDsl` parse tree into a [CtlExpr]. Atoms are resolved against the [vars] symbol table;
+ * `->` and `<->` are desugared into and/or/not.
  */
 class CtlExprVisitor(private val vars: Map<String, VarDecl<*>>) : CtlDslBaseVisitor<CtlExpr>() {
 
   override fun visitModel(ctx: ModelContext): CtlExpr = visit(ctx.iffExpr())
 
-  // a <-> b  ==  (!a | b) & (!b | a); left-folded over the operand list.
+  // a <-> b  ==  (!a | b) & (!b | a)
   override fun visitIffExpr(ctx: IffExprContext): CtlExpr {
     var acc = visit(ctx.ops[0])
     for (i in 1 until ctx.ops.size) {
@@ -62,7 +55,7 @@ class CtlExprVisitor(private val vars: Map<String, VarDecl<*>>) : CtlDslBaseVisi
     return acc
   }
 
-  // a -> b  ==  !a | b; right-associative (a -> b -> c == a -> (b -> c)).
+  // a -> b  ==  !a | b, right-associative
   override fun visitImplyExpr(ctx: ImplyExprContext): CtlExpr {
     var acc = visit(ctx.ops.last())
     for (i in ctx.ops.size - 2 downTo 0) {
@@ -102,13 +95,12 @@ class CtlExprVisitor(private val vars: Map<String, VarDecl<*>>) : CtlDslBaseVisi
   override fun visitAtomExpr(ctx: AtomExprContext): CtlExpr =
     CtlExpr.Atom(buildBool(ctx.atom().relationExpr()))
 
-  // --- atom (state-predicate) construction ----------------------------------------------------
-
   private fun buildBool(ctx: RelationExprContext): Expr<BoolType> {
     val left = buildArith(ctx.ops[0])
     if (ctx.oper == null) {
-      // bare boolean atom: a boolean variable or literal
-      require(left.type is BoolType) { "Atom '${ctx.text}' is not a boolean expression" }
+      if (left.type !is BoolType) {
+        throw CtlParseException("Atom '${ctx.text}' is not a boolean expression")
+      }
       @Suppress("UNCHECKED_CAST") return left as Expr<BoolType>
     }
     val right = buildArith(ctx.ops[1])
@@ -121,7 +113,7 @@ class CtlExprVisitor(private val vars: Map<String, VarDecl<*>>) : CtlDslBaseVisi
         op.GT() != null -> Gt(left, right)
         op.LEQ() != null -> Leq(left, right)
         op.GEQ() != null -> Geq(left, right)
-        else -> error("Unknown relational operator '${op.text}'")
+        else -> throw CtlParseException("Unknown relational operator '${op.text}'")
       }
     @Suppress("UNCHECKED_CAST") return result as Expr<BoolType>
   }
@@ -156,10 +148,10 @@ class CtlExprVisitor(private val vars: Map<String, VarDecl<*>>) : CtlDslBaseVisi
       is BoolLitExprContext -> if (ctx.value.text == "true") True() else False()
       is VarExprContext -> {
         val name = ctx.name.text
-        (vars[name] ?: error("Unknown variable '$name'")).ref
+        (vars[name] ?: throw CtlParseException("Unknown variable '$name'")).ref
       }
       is NegArithExprContext -> Neg(buildPrimary(ctx.op))
       is ParenArithExprContext -> buildArith(ctx.additiveExpr())
-      else -> error("Unknown arithmetic expression '${ctx.text}'")
+      else -> throw CtlParseException("Unknown arithmetic expression '${ctx.text}'")
     }
 }

--- a/subprojects/common/ctl/src/main/kotlin/hu/bme/mit/theta/ctl/CtlExprVisitor.kt
+++ b/subprojects/common/ctl/src/main/kotlin/hu/bme/mit/theta/ctl/CtlExprVisitor.kt
@@ -1,0 +1,165 @@
+/*
+ *  Copyright 2026 Budapest University of Technology and Economics
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package hu.bme.mit.theta.ctl
+
+import hu.bme.mit.theta.analysis.algorithm.mdd.ctl.CtlExpr
+import hu.bme.mit.theta.core.decl.VarDecl
+import hu.bme.mit.theta.core.type.Expr
+import hu.bme.mit.theta.core.type.abstracttype.AbstractExprs.Add
+import hu.bme.mit.theta.core.type.abstracttype.AbstractExprs.Div
+import hu.bme.mit.theta.core.type.abstracttype.AbstractExprs.Eq
+import hu.bme.mit.theta.core.type.abstracttype.AbstractExprs.Geq
+import hu.bme.mit.theta.core.type.abstracttype.AbstractExprs.Gt
+import hu.bme.mit.theta.core.type.abstracttype.AbstractExprs.Leq
+import hu.bme.mit.theta.core.type.abstracttype.AbstractExprs.Lt
+import hu.bme.mit.theta.core.type.abstracttype.AbstractExprs.Mod
+import hu.bme.mit.theta.core.type.abstracttype.AbstractExprs.Mul
+import hu.bme.mit.theta.core.type.abstracttype.AbstractExprs.Neg
+import hu.bme.mit.theta.core.type.abstracttype.AbstractExprs.Neq
+import hu.bme.mit.theta.core.type.abstracttype.AbstractExprs.Sub
+import hu.bme.mit.theta.core.type.booltype.BoolExprs.False
+import hu.bme.mit.theta.core.type.booltype.BoolExprs.True
+import hu.bme.mit.theta.core.type.booltype.BoolType
+import hu.bme.mit.theta.core.type.inttype.IntExprs.Int
+import hu.bme.mit.theta.ctl.dsl.gen.CtlDslBaseVisitor
+import hu.bme.mit.theta.ctl.dsl.gen.CtlDslParser.*
+
+/**
+ * Folds a `CtlDsl` parse tree into a [CtlExpr].
+ *
+ * The CTL boolean operators (`!`, `&`, `|`, `->`, `<->`) live at the formula level and become
+ * [CtlExpr.Not]/[CtlExpr.And]/[CtlExpr.Or] (with `->`/`<->` desugared). An atom is a relational
+ * expression over arithmetic (or a bare boolean variable/literal); it is turned into an
+ * `Expr<BoolType>` with the supplied [vars] symbol table and wrapped in [CtlExpr.Atom].
+ *
+ * The visitor is pure — it produces the AST only; all MDD/semantic work happens later in the
+ * checker.
+ */
+class CtlExprVisitor(private val vars: Map<String, VarDecl<*>>) : CtlDslBaseVisitor<CtlExpr>() {
+
+  override fun visitModel(ctx: ModelContext): CtlExpr = visit(ctx.iffExpr())
+
+  // a <-> b  ==  (!a | b) & (!b | a); left-folded over the operand list.
+  override fun visitIffExpr(ctx: IffExprContext): CtlExpr {
+    var acc = visit(ctx.ops[0])
+    for (i in 1 until ctx.ops.size) {
+      val b = visit(ctx.ops[i])
+      acc = CtlExpr.And(CtlExpr.Or(CtlExpr.Not(acc), b), CtlExpr.Or(CtlExpr.Not(b), acc))
+    }
+    return acc
+  }
+
+  // a -> b  ==  !a | b; right-associative (a -> b -> c == a -> (b -> c)).
+  override fun visitImplyExpr(ctx: ImplyExprContext): CtlExpr {
+    var acc = visit(ctx.ops.last())
+    for (i in ctx.ops.size - 2 downTo 0) {
+      acc = CtlExpr.Or(CtlExpr.Not(visit(ctx.ops[i])), acc)
+    }
+    return acc
+  }
+
+  override fun visitOrExpr(ctx: OrExprContext): CtlExpr =
+    ctx.ops.map { visit(it) }.reduce { a, b -> CtlExpr.Or(a, b) }
+
+  override fun visitAndExpr(ctx: AndExprContext): CtlExpr =
+    ctx.ops.map { visit(it) }.reduce { a, b -> CtlExpr.And(a, b) }
+
+  override fun visitNotExpr(ctx: NotExprContext): CtlExpr = CtlExpr.Not(visit(ctx.op))
+
+  override fun visitExExpr(ctx: ExExprContext): CtlExpr = CtlExpr.EX(visit(ctx.op))
+
+  override fun visitEfExpr(ctx: EfExprContext): CtlExpr = CtlExpr.EF(visit(ctx.op))
+
+  override fun visitEgExpr(ctx: EgExprContext): CtlExpr = CtlExpr.EG(visit(ctx.op))
+
+  override fun visitAxExpr(ctx: AxExprContext): CtlExpr = CtlExpr.AX(visit(ctx.op))
+
+  override fun visitAfExpr(ctx: AfExprContext): CtlExpr = CtlExpr.AF(visit(ctx.op))
+
+  override fun visitAgExpr(ctx: AgExprContext): CtlExpr = CtlExpr.AG(visit(ctx.op))
+
+  override fun visitQuantPassthrough(ctx: QuantPassthroughContext): CtlExpr = visit(ctx.quantExpr())
+
+  override fun visitEuExpr(ctx: EuExprContext): CtlExpr = CtlExpr.EU(visit(ctx.l), visit(ctx.r))
+
+  override fun visitAuExpr(ctx: AuExprContext): CtlExpr = CtlExpr.AU(visit(ctx.l), visit(ctx.r))
+
+  override fun visitParenCtlExpr(ctx: ParenCtlExprContext): CtlExpr = visit(ctx.iffExpr())
+
+  override fun visitAtomExpr(ctx: AtomExprContext): CtlExpr =
+    CtlExpr.Atom(buildBool(ctx.atom().relationExpr()))
+
+  // --- atom (state-predicate) construction ----------------------------------------------------
+
+  private fun buildBool(ctx: RelationExprContext): Expr<BoolType> {
+    val left = buildArith(ctx.ops[0])
+    if (ctx.oper == null) {
+      // bare boolean atom: a boolean variable or literal
+      require(left.type is BoolType) { "Atom '${ctx.text}' is not a boolean expression" }
+      @Suppress("UNCHECKED_CAST") return left as Expr<BoolType>
+    }
+    val right = buildArith(ctx.ops[1])
+    val op = ctx.oper
+    val result =
+      when {
+        op.EQ() != null -> Eq(left, right)
+        op.NEQ() != null -> Neq(left, right)
+        op.LT() != null -> Lt(left, right)
+        op.GT() != null -> Gt(left, right)
+        op.LEQ() != null -> Leq(left, right)
+        op.GEQ() != null -> Geq(left, right)
+        else -> error("Unknown relational operator '${op.text}'")
+      }
+    @Suppress("UNCHECKED_CAST") return result as Expr<BoolType>
+  }
+
+  private fun buildArith(ctx: AdditiveExprContext): Expr<*> {
+    var acc = buildMul(ctx.ops[0])
+    for (i in 1 until ctx.ops.size) {
+      val rhs = buildMul(ctx.ops[i])
+      acc = if (ctx.opers[i - 1].PLUS() != null) Add(acc, rhs) else Sub(acc, rhs)
+    }
+    return acc
+  }
+
+  private fun buildMul(ctx: MultiplicativeExprContext): Expr<*> {
+    var acc = buildPrimary(ctx.ops[0])
+    for (i in 1 until ctx.ops.size) {
+      val rhs = buildPrimary(ctx.ops[i])
+      val op = ctx.opers[i - 1]
+      acc =
+        when {
+          op.MUL() != null -> Mul(acc, rhs)
+          op.DIV() != null -> Div(acc, rhs)
+          else -> Mod(acc, rhs)
+        }
+    }
+    return acc
+  }
+
+  private fun buildPrimary(ctx: PrimaryArithContext): Expr<*> =
+    when (ctx) {
+      is IntLitExprContext -> Int(ctx.value.text)
+      is BoolLitExprContext -> if (ctx.value.text == "true") True() else False()
+      is VarExprContext -> {
+        val name = ctx.name.text
+        (vars[name] ?: error("Unknown variable '$name'")).ref
+      }
+      is NegArithExprContext -> Neg(buildPrimary(ctx.op))
+      is ParenArithExprContext -> buildArith(ctx.additiveExpr())
+      else -> error("Unknown arithmetic expression '${ctx.text}'")
+    }
+}

--- a/subprojects/common/ctl/src/main/kotlin/hu/bme/mit/theta/ctl/CtlParser.kt
+++ b/subprojects/common/ctl/src/main/kotlin/hu/bme/mit/theta/ctl/CtlParser.kt
@@ -1,0 +1,62 @@
+/*
+ *  Copyright 2026 Budapest University of Technology and Economics
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package hu.bme.mit.theta.ctl
+
+import hu.bme.mit.theta.analysis.algorithm.mdd.ctl.CtlExpr
+import hu.bme.mit.theta.core.decl.VarDecl
+import hu.bme.mit.theta.ctl.dsl.gen.CtlDslLexer
+import hu.bme.mit.theta.ctl.dsl.gen.CtlDslParser
+import org.antlr.v4.runtime.BaseErrorListener
+import org.antlr.v4.runtime.CharStreams
+import org.antlr.v4.runtime.CommonTokenStream
+import org.antlr.v4.runtime.RecognitionException
+import org.antlr.v4.runtime.Recognizer
+
+/** Thrown when a CTL formula cannot be parsed. */
+class CtlParseException(message: String) : RuntimeException(message)
+
+/** Parses CTL formulas (the `CtlDsl` grammar) into [CtlExpr] over a given set of variables. */
+object CtlParser {
+
+  /** Parses [input] into a [CtlExpr], resolving atoms against [vars] (keyed by name). */
+  fun parse(input: String, vars: Map<String, VarDecl<*>>): CtlExpr {
+    val lexer = CtlDslLexer(CharStreams.fromString(input))
+    val parser = CtlDslParser(CommonTokenStream(lexer))
+    val errorListener =
+      object : BaseErrorListener() {
+        override fun syntaxError(
+          recognizer: Recognizer<*, *>?,
+          offendingSymbol: Any?,
+          line: Int,
+          charPositionInLine: Int,
+          msg: String?,
+          e: RecognitionException?,
+        ) {
+          throw CtlParseException("Syntax error at $line:$charPositionInLine - $msg")
+        }
+      }
+    lexer.removeErrorListeners()
+    lexer.addErrorListener(errorListener)
+    parser.removeErrorListeners()
+    parser.addErrorListener(errorListener)
+
+    return CtlExprVisitor(vars).visit(parser.model())
+  }
+
+  /** Parses [input], resolving atoms against [vars] (keyed by [VarDecl.getName]). */
+  fun parse(input: String, vars: Collection<VarDecl<*>>): CtlExpr =
+    parse(input, vars.associateBy { it.name })
+}

--- a/subprojects/common/ctl/src/main/kotlin/hu/bme/mit/theta/ctl/CtlParser.kt
+++ b/subprojects/common/ctl/src/main/kotlin/hu/bme/mit/theta/ctl/CtlParser.kt
@@ -31,7 +31,6 @@ class CtlParseException(message: String) : RuntimeException(message)
 /** Parses CTL formulas (the `CtlDsl` grammar) into [CtlExpr] over a given set of variables. */
 object CtlParser {
 
-  /** Parses [input] into a [CtlExpr], resolving atoms against [vars] (keyed by name). */
   fun parse(input: String, vars: Map<String, VarDecl<*>>): CtlExpr {
     val lexer = CtlDslLexer(CharStreams.fromString(input))
     val parser = CtlDslParser(CommonTokenStream(lexer))
@@ -56,7 +55,6 @@ object CtlParser {
     return CtlExprVisitor(vars).visit(parser.model())
   }
 
-  /** Parses [input], resolving atoms against [vars] (keyed by [VarDecl.getName]). */
   fun parse(input: String, vars: Collection<VarDecl<*>>): CtlExpr =
     parse(input, vars.associateBy { it.name })
 }

--- a/subprojects/common/ctl/src/test/kotlin/hu/bme/mit/theta/ctl/CtlParserTest.kt
+++ b/subprojects/common/ctl/src/test/kotlin/hu/bme/mit/theta/ctl/CtlParserTest.kt
@@ -1,0 +1,120 @@
+/*
+ *  Copyright 2026 Budapest University of Technology and Economics
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package hu.bme.mit.theta.ctl
+
+import hu.bme.mit.delta.mdd.MddInterpreter
+import hu.bme.mit.theta.analysis.algorithm.bounded.MonolithicExpr
+import hu.bme.mit.theta.analysis.algorithm.mdd.ctl.CtlExpr
+import hu.bme.mit.theta.analysis.algorithm.mdd.ctl.MddCtlChecker
+import hu.bme.mit.theta.common.logging.NullLogger
+import hu.bme.mit.theta.core.decl.Decls
+import hu.bme.mit.theta.core.type.abstracttype.AbstractExprs.Add
+import hu.bme.mit.theta.core.type.abstracttype.AbstractExprs.Eq
+import hu.bme.mit.theta.core.type.abstracttype.AbstractExprs.Lt
+import hu.bme.mit.theta.core.type.anytype.Exprs.Prime
+import hu.bme.mit.theta.core.type.booltype.BoolExprs.Or
+import hu.bme.mit.theta.core.type.booltype.BoolExprs.True
+import hu.bme.mit.theta.core.type.booltype.SmartBoolExprs.And
+import hu.bme.mit.theta.core.type.inttype.IntExprs.Int
+import hu.bme.mit.theta.core.type.inttype.IntType
+import hu.bme.mit.theta.solver.SolverPool
+import hu.bme.mit.theta.solver.z3legacy.Z3LegacySolverFactory
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class CtlParserTest {
+
+  private val x = Decls.Var("x", IntType.getInstance())
+  private val vars = listOf(x)
+
+  private fun parse(s: String): CtlExpr = CtlParser.parse(s, vars)
+
+  // --- pure parsing (no MDD backend) ----------------------------------------------------------
+
+  @Test
+  fun parsesPrimitivesAndAtoms() {
+    assertEquals(CtlExpr.EX(CtlExpr.Atom(Eq(x.ref, Int(1)))), parse("EX x = 1"))
+    assertEquals(CtlExpr.EG(CtlExpr.Atom(Lt(x.ref, Int(3)))), parse("EG x < 3"))
+    assertEquals(
+      CtlExpr.EU(CtlExpr.Atom(Lt(x.ref, Int(3))), CtlExpr.Atom(Eq(x.ref, Int(3)))),
+      parse("E[ x < 3 U x = 3 ]"),
+    )
+  }
+
+  @Test
+  fun parsesBooleanCombinatorsAtFormulaLevel() {
+    // `&` binds tighter than `|`; atoms are relational, so this is Or(And(a,b), c)
+    val expected =
+      CtlExpr.Or(
+        CtlExpr.And(CtlExpr.Atom(Lt(x.ref, Int(3))), CtlExpr.Atom(Eq(x.ref, Int(1)))),
+        CtlExpr.Atom(Eq(x.ref, Int(2))),
+      )
+    assertEquals(expected, parse("x < 3 & x = 1 | x = 2"))
+  }
+
+  @Test
+  fun desugarsImplicationAndNegation() {
+    // a -> b == !a | b
+    assertEquals(
+      CtlExpr.Or(CtlExpr.Not(CtlExpr.Atom(Eq(x.ref, Int(0)))), CtlExpr.Atom(Eq(x.ref, Int(1)))),
+      parse("x = 0 -> x = 1"),
+    )
+    assertEquals(CtlExpr.Not(CtlExpr.EX(CtlExpr.Atom(Eq(x.ref, Int(1))))), parse("!EX x = 1"))
+  }
+
+  @Test
+  fun parsesArithmeticInsideAtoms() {
+    assertEquals(CtlExpr.Atom(Lt(Add(x.ref, Int(1)), Int(5))), parse("x + 1 < 5"))
+  }
+
+  @Test
+  fun rejectsGarbageAndUnknownVariables() {
+    assertThrows(CtlParseException::class.java) { parse("EX EX") }
+    assertThrows(IllegalStateException::class.java) { parse("y = 0") }
+  }
+
+  // --- end to end: parse -> check (same counter model as MddCtlCheckerTest) --------------------
+
+  private fun <T> withChecker(block: (MddCtlChecker) -> T): T {
+    val init = Eq(x.ref, Int(0))
+    val trans =
+      Or(
+        And(Lt(x.ref, Int(3)), Eq(Prime(x.ref), Add(x.ref, Int(1)))),
+        And(Eq(x.ref, Int(3)), Eq(Prime(x.ref), x.ref)),
+      )
+    val monolithicExpr = MonolithicExpr(init, trans, True())
+    SolverPool(Z3LegacySolverFactory.getInstance()).use { pool ->
+      return block(MddCtlChecker(monolithicExpr, pool, NullLogger.getInstance()))
+    }
+  }
+
+  @Test
+  fun parsedFormulasCheckCorrectly() = withChecker { c ->
+    assertTrue(c.isSatisfied(parse("EF x = 3")))
+    assertTrue(c.isSatisfied(parse("AF x = 3")))
+    assertTrue(c.isSatisfied(parse("EX x = 1")))
+    assertFalse(c.isSatisfied(parse("EX x = 2")))
+    assertFalse(c.isSatisfied(parse("EG x = 3")))
+    assertTrue(c.isSatisfied(parse("AG x <= 3")))
+    assertFalse(c.isSatisfied(parse("AG !(x = 2)")))
+    assertTrue(c.isSatisfied(parse("E[ x < 3 U x = 3 ]")))
+    // EF x=3 set has all 4 states
+    assertEquals(4L, MddInterpreter.calculateNonzeroCount(c.check(parse("EF x = 3"))))
+  }
+}

--- a/subprojects/common/ctl/src/test/kotlin/hu/bme/mit/theta/ctl/CtlParserTest.kt
+++ b/subprojects/common/ctl/src/test/kotlin/hu/bme/mit/theta/ctl/CtlParserTest.kt
@@ -45,8 +45,6 @@ class CtlParserTest {
 
   private fun parse(s: String): CtlExpr = CtlParser.parse(s, vars)
 
-  // --- pure parsing (no MDD backend) ----------------------------------------------------------
-
   @Test
   fun parsesPrimitivesAndAtoms() {
     assertEquals(CtlExpr.EX(CtlExpr.Atom(Eq(x.ref, Int(1)))), parse("EX x = 1"))
@@ -59,7 +57,7 @@ class CtlParserTest {
 
   @Test
   fun parsesBooleanCombinatorsAtFormulaLevel() {
-    // `&` binds tighter than `|`; atoms are relational, so this is Or(And(a,b), c)
+    // & binds tighter than |
     val expected =
       CtlExpr.Or(
         CtlExpr.And(CtlExpr.Atom(Lt(x.ref, Int(3))), CtlExpr.Atom(Eq(x.ref, Int(1)))),
@@ -70,7 +68,6 @@ class CtlParserTest {
 
   @Test
   fun desugarsImplicationAndNegation() {
-    // a -> b == !a | b
     assertEquals(
       CtlExpr.Or(CtlExpr.Not(CtlExpr.Atom(Eq(x.ref, Int(0)))), CtlExpr.Atom(Eq(x.ref, Int(1)))),
       parse("x = 0 -> x = 1"),
@@ -86,11 +83,10 @@ class CtlParserTest {
   @Test
   fun rejectsGarbageAndUnknownVariables() {
     assertThrows(CtlParseException::class.java) { parse("EX EX") }
-    assertThrows(IllegalStateException::class.java) { parse("y = 0") }
+    assertThrows(CtlParseException::class.java) { parse("y = 0") }
   }
 
-  // --- end to end: parse -> check (same counter model as MddCtlCheckerTest) --------------------
-
+  // same counter model as MddCtlCheckerTest
   private fun <T> withChecker(block: (MddCtlChecker) -> T): T {
     val init = Eq(x.ref, Int(0))
     val trans =
@@ -114,7 +110,6 @@ class CtlParserTest {
     assertTrue(c.isSatisfied(parse("AG x <= 3")))
     assertFalse(c.isSatisfied(parse("AG !(x = 2)")))
     assertTrue(c.isSatisfied(parse("E[ x < 3 U x = 3 ]")))
-    // EF x=3 set has all 4 states
     assertEquals(4L, MddInterpreter.calculateNonzeroCount(c.check(parse("EF x = 3"))))
   }
 }

--- a/subprojects/frontends/petrinet-xsts/build.gradle.kts
+++ b/subprojects/frontends/petrinet-xsts/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2025 Budapest University of Technology and Economics
+ *  Copyright 2026 Budapest University of Technology and Economics
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/subprojects/frontends/petrinet-xsts/build.gradle.kts
+++ b/subprojects/frontends/petrinet-xsts/build.gradle.kts
@@ -28,4 +28,5 @@ dependencies {
     testImplementation(project(":theta-solver-z3-legacy"))
     testImplementation(project(":theta-solver"))
     testImplementation(project(":theta-analysis"))
+    testImplementation(project(":theta-ctl"))
 }

--- a/subprojects/frontends/petrinet-xsts/src/test/kotlin/hu/bme/mit/theta/frontend/petrinet/xsts/PhilosophersCtlTest.kt
+++ b/subprojects/frontends/petrinet-xsts/src/test/kotlin/hu/bme/mit/theta/frontend/petrinet/xsts/PhilosophersCtlTest.kt
@@ -1,0 +1,87 @@
+/*
+ *  Copyright 2026 Budapest University of Technology and Economics
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package hu.bme.mit.theta.frontend.petrinet.xsts
+
+import hu.bme.mit.theta.analysis.algorithm.mdd.ctl.MddCtlChecker
+import hu.bme.mit.theta.common.logging.NullLogger
+import hu.bme.mit.theta.ctl.CtlParser
+import hu.bme.mit.theta.frontend.petrinet.pnml.XMLPnmlToPetrinet
+import hu.bme.mit.theta.solver.SolverPool
+import hu.bme.mit.theta.solver.z3legacy.Z3LegacySolverFactory
+import hu.bme.mit.theta.xsts.analysis.XstsToMonolithicAdapter
+import java.io.ByteArrayInputStream
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Symbolic CTL model checking of the 5-philosopher dining net. The eating places are Eat_1 ..
+ * Eat_5; philosopher i shares a fork with philosophers i-1 and i+1 (wrap-around). This net has no
+ * deadlock-avoidance, so it can deadlock.
+ */
+class PhilosophersCtlTest {
+
+  private fun check(property: String): Boolean {
+    val petriNet = XMLPnmlToPetrinet.parse("src/test/resources/pnml/Philosophers-5.pnml", "")
+    val xsts =
+      ByteArrayInputStream("prop { true }".toByteArray()).use {
+        PetriNetToXSTS.createXSTS(petriNet, it)
+      }
+    val monolithicExpr = XstsToMonolithicAdapter(xsts).monolithicExpr
+    return SolverPool(Z3LegacySolverFactory.getInstance()).use { pool ->
+      val checker = MddCtlChecker(monolithicExpr, pool, NullLogger.getInstance())
+      checker.isSatisfied(CtlParser.parse(property, monolithicExpr.vars))
+    }
+  }
+
+  @Test
+  fun eachPhilosopherCanEat() {
+    for (i in 1..5) assertTrue(check("EF(Eat_$i > 0)"), "philosopher $i should be able to eat")
+  }
+
+  @Test
+  fun nonAdjacentPhilosophersCanEatConcurrently() {
+    // 1 and 3 share no fork, so they can hold all four needed forks at once
+    assertTrue(check("EF(Eat_1 > 0 & Eat_3 > 0)"))
+  }
+
+  @Test
+  fun adjacentPhilosophersNeverEatConcurrently() {
+    // shared fork enforces mutual exclusion between neighbours
+    assertTrue(check("AG(!(Eat_1 > 0 & Eat_2 > 0))"))
+    assertTrue(check("AG(!(Eat_5 > 0 & Eat_1 > 0))"))
+  }
+
+  @Test
+  fun netCanDeadlock() {
+    // AG EX true asserts every reachable state has a successor; it fails because all five can grab
+    // their left fork and block
+    assertFalse(check("AG(EX(true))"))
+  }
+
+  @Test
+  fun aPhilosopherCanStarve() {
+    // from the deadlock state eating is no longer reachable, so the recurrence property fails
+    assertFalse(check("AG(EF(Eat_1 > 0))"))
+  }
+
+  @Test
+  fun universalLivenessFails() {
+    assertFalse(
+      check("AG(EF(Eat_1 > 0) & EF(Eat_2 > 0) & EF(Eat_3 > 0) & EF(Eat_4 > 0) & EF(Eat_5 > 0))")
+    )
+  }
+}

--- a/subprojects/sts/sts-cli/src/main/java/hu/bme/mit/theta/sts/cli/StsCli.java
+++ b/subprojects/sts/sts-cli/src/main/java/hu/bme/mit/theta/sts/cli/StsCli.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2025 Budapest University of Technology and Economics
+ *  Copyright 2026 Budapest University of Technology and Economics
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/subprojects/sts/sts-cli/src/main/java/hu/bme/mit/theta/sts/cli/StsCli.java
+++ b/subprojects/sts/sts-cli/src/main/java/hu/bme/mit/theta/sts/cli/StsCli.java
@@ -35,6 +35,7 @@ import hu.bme.mit.theta.analysis.algorithm.bounded.pipeline.passes.ReverseMEPass
 import hu.bme.mit.theta.analysis.algorithm.cegar.CegarStatistics;
 import hu.bme.mit.theta.analysis.algorithm.ic3.Ic3Checker;
 import hu.bme.mit.theta.analysis.algorithm.mdd.MddChecker;
+import hu.bme.mit.theta.analysis.algorithm.mdd.fixedpoint.IterationStrategy;
 import hu.bme.mit.theta.analysis.expl.ExplState;
 import hu.bme.mit.theta.analysis.expr.ExprAction;
 import hu.bme.mit.theta.analysis.expr.ExprState;
@@ -261,7 +262,7 @@ public class StsCli {
     @Parameter(
             names = {"--iteration-strategy"},
             description = "MDD iteration strategy")
-    MddChecker.IterationStrategy iterationStrategy = MddChecker.IterationStrategy.GSAT;
+    IterationStrategy iterationStrategy = IterationStrategy.GSAT;
 
     @Parameter(
             names = {"--smt-home"},

--- a/subprojects/xcfa/xcfa-cli/src/main/java/hu/bme/mit/theta/xcfa/cli/params/XcfaConfig.kt
+++ b/subprojects/xcfa/xcfa-cli/src/main/java/hu/bme/mit/theta/xcfa/cli/params/XcfaConfig.kt
@@ -18,8 +18,8 @@ package hu.bme.mit.theta.xcfa.cli.params
 import com.beust.jcommander.Parameter
 import hu.bme.mit.theta.analysis.algorithm.loopchecker.abstraction.LoopCheckerSearchStrategy
 import hu.bme.mit.theta.analysis.algorithm.loopchecker.refinement.ASGTraceCheckerStrategy
-import hu.bme.mit.theta.analysis.algorithm.mdd.MddChecker.IterationStrategy
 import hu.bme.mit.theta.analysis.algorithm.mdd.expressionnode.MddExpressionRepresentation
+import hu.bme.mit.theta.analysis.algorithm.mdd.fixedpoint.IterationStrategy
 import hu.bme.mit.theta.analysis.expr.refinement.PruneStrategy
 import hu.bme.mit.theta.common.logging.Logger
 import hu.bme.mit.theta.frontend.ParseContext

--- a/subprojects/xcfa/xcfa-cli/src/main/java/hu/bme/mit/theta/xcfa/cli/portfolio/utils.kt
+++ b/subprojects/xcfa/xcfa-cli/src/main/java/hu/bme/mit/theta/xcfa/cli/portfolio/utils.kt
@@ -17,7 +17,7 @@ package hu.bme.mit.theta.xcfa.cli.portfolio
 
 import hu.bme.mit.theta.analysis.algorithm.loopchecker.abstraction.LoopCheckerSearchStrategy
 import hu.bme.mit.theta.analysis.algorithm.loopchecker.refinement.ASGTraceCheckerStrategy
-import hu.bme.mit.theta.analysis.algorithm.mdd.MddChecker
+import hu.bme.mit.theta.analysis.algorithm.mdd.fixedpoint.IterationStrategy
 import hu.bme.mit.theta.analysis.expr.refinement.PruneStrategy.FULL
 import hu.bme.mit.theta.analysis.expr.refinement.PruneStrategy.LAZY
 import hu.bme.mit.theta.frontend.ParseContext
@@ -382,7 +382,7 @@ fun baseMddConfig(
           MddConfig(
             solver = "Z3",
             validateSolver = false,
-            iterationStrategy = MddChecker.IterationStrategy.GSAT,
+            iterationStrategy = IterationStrategy.GSAT,
             reversed = false,
             cegar = false,
             initPrec = EMPTY,

--- a/subprojects/xsts/xsts-analysis/src/test/java/hu/bme/mit/theta/xsts/analysis/XstsBfsMddCheckerTest.java
+++ b/subprojects/xsts/xsts-analysis/src/test/java/hu/bme/mit/theta/xsts/analysis/XstsBfsMddCheckerTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2025 Budapest University of Technology and Economics
+ *  Copyright 2026 Budapest University of Technology and Economics
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/subprojects/xsts/xsts-analysis/src/test/java/hu/bme/mit/theta/xsts/analysis/XstsBfsMddCheckerTest.java
+++ b/subprojects/xsts/xsts-analysis/src/test/java/hu/bme/mit/theta/xsts/analysis/XstsBfsMddCheckerTest.java
@@ -15,7 +15,7 @@
  */
 package hu.bme.mit.theta.xsts.analysis;
 
-import hu.bme.mit.theta.analysis.algorithm.mdd.MddChecker.IterationStrategy;
+import hu.bme.mit.theta.analysis.algorithm.mdd.fixedpoint.IterationStrategy;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 

--- a/subprojects/xsts/xsts-analysis/src/test/java/hu/bme/mit/theta/xsts/analysis/XstsGsatMddCheckerTest.java
+++ b/subprojects/xsts/xsts-analysis/src/test/java/hu/bme/mit/theta/xsts/analysis/XstsGsatMddCheckerTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2025 Budapest University of Technology and Economics
+ *  Copyright 2026 Budapest University of Technology and Economics
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/subprojects/xsts/xsts-analysis/src/test/java/hu/bme/mit/theta/xsts/analysis/XstsGsatMddCheckerTest.java
+++ b/subprojects/xsts/xsts-analysis/src/test/java/hu/bme/mit/theta/xsts/analysis/XstsGsatMddCheckerTest.java
@@ -15,7 +15,7 @@
  */
 package hu.bme.mit.theta.xsts.analysis;
 
-import hu.bme.mit.theta.analysis.algorithm.mdd.MddChecker.IterationStrategy;
+import hu.bme.mit.theta.analysis.algorithm.mdd.fixedpoint.IterationStrategy;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 

--- a/subprojects/xsts/xsts-analysis/src/test/java/hu/bme/mit/theta/xsts/analysis/XstsMddCheckerTest.java
+++ b/subprojects/xsts/xsts-analysis/src/test/java/hu/bme/mit/theta/xsts/analysis/XstsMddCheckerTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2025 Budapest University of Technology and Economics
+ *  Copyright 2026 Budapest University of Technology and Economics
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/subprojects/xsts/xsts-analysis/src/test/java/hu/bme/mit/theta/xsts/analysis/XstsMddCheckerTest.java
+++ b/subprojects/xsts/xsts-analysis/src/test/java/hu/bme/mit/theta/xsts/analysis/XstsMddCheckerTest.java
@@ -21,7 +21,7 @@ import hu.bme.mit.theta.analysis.Trace;
 import hu.bme.mit.theta.analysis.algorithm.InvariantProof;
 import hu.bme.mit.theta.analysis.algorithm.SafetyResult;
 import hu.bme.mit.theta.analysis.algorithm.mdd.MddChecker;
-import hu.bme.mit.theta.analysis.algorithm.mdd.MddChecker.IterationStrategy;
+import hu.bme.mit.theta.analysis.algorithm.mdd.fixedpoint.IterationStrategy;
 import hu.bme.mit.theta.analysis.expr.ExprState;
 import hu.bme.mit.theta.common.logging.ConsoleLogger;
 import hu.bme.mit.theta.common.logging.Logger;

--- a/subprojects/xsts/xsts-analysis/src/test/java/hu/bme/mit/theta/xsts/analysis/XstsSatMddCheckerTest.java
+++ b/subprojects/xsts/xsts-analysis/src/test/java/hu/bme/mit/theta/xsts/analysis/XstsSatMddCheckerTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2025 Budapest University of Technology and Economics
+ *  Copyright 2026 Budapest University of Technology and Economics
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/subprojects/xsts/xsts-analysis/src/test/java/hu/bme/mit/theta/xsts/analysis/XstsSatMddCheckerTest.java
+++ b/subprojects/xsts/xsts-analysis/src/test/java/hu/bme/mit/theta/xsts/analysis/XstsSatMddCheckerTest.java
@@ -15,7 +15,7 @@
  */
 package hu.bme.mit.theta.xsts.analysis;
 
-import hu.bme.mit.theta.analysis.algorithm.mdd.MddChecker.IterationStrategy;
+import hu.bme.mit.theta.analysis.algorithm.mdd.fixedpoint.IterationStrategy;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;

--- a/subprojects/xsts/xsts-cli/build.gradle.kts
+++ b/subprojects/xsts/xsts-cli/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     implementation(project(":theta-common"))
     implementation(project(":theta-ltl"))
     implementation(project(":theta-ltl-cli"))
+    implementation(project(":theta-ctl"))
     implementation(project(":theta-cfa"))
     implementation(project(":theta-solver"))
     implementation(project(":theta-solver-z3-legacy"))

--- a/subprojects/xsts/xsts-cli/src/main/kotlin/hu/bme/mit/theta/xsts/cli/XstsCliCtl.kt
+++ b/subprojects/xsts/xsts-cli/src/main/kotlin/hu/bme/mit/theta/xsts/cli/XstsCliCtl.kt
@@ -1,0 +1,93 @@
+/*
+ *  Copyright 2026 Budapest University of Technology and Economics
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package hu.bme.mit.theta.xsts.cli
+
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.enum
+import com.github.ajalt.clikt.parameters.types.file
+import com.google.common.base.Stopwatch
+import hu.bme.mit.theta.analysis.Trace
+import hu.bme.mit.theta.analysis.algorithm.SafetyResult
+import hu.bme.mit.theta.analysis.algorithm.mdd.MddProof
+import hu.bme.mit.theta.analysis.algorithm.mdd.ctl.MddCtlChecker
+import hu.bme.mit.theta.analysis.algorithm.mdd.expressionnode.MddExpressionRepresentation
+import hu.bme.mit.theta.analysis.expl.ExplState
+import hu.bme.mit.theta.analysis.expr.ExprAction
+import hu.bme.mit.theta.ctl.CtlParser
+import hu.bme.mit.theta.solver.SolverManager
+import hu.bme.mit.theta.solver.SolverPool
+import hu.bme.mit.theta.xsts.analysis.XstsToMonolithicAdapter
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+class XstsCliCtl :
+  XstsCliBaseCommand(
+    name = "CTL",
+    help = "Symbolic CTL model checking of XSTS using MDDs (Multi-value Decision Diagrams)",
+  ) {
+
+  private val ctlProperty: File? by
+    option(help = "Path of the CTL property file. Has priority over --ctl-expression")
+      .file(mustExist = true, canBeDir = false, mustBeReadable = true)
+
+  private val ctlExpression: String? by
+    option(help = "CTL property as a string. Ignored if --ctl-property is defined")
+
+  private val lookAheadStrategy: MddExpressionRepresentation.MddToExprStrategy by
+    option(help = "The MDD to expression conversion strategy")
+      .enum<MddExpressionRepresentation.MddToExprStrategy>()
+      .default(MddExpressionRepresentation.MddToExprStrategy.VARIABLE_LEVEL)
+
+  private val euStrategy: MddCtlChecker.EuStrategy by
+    option(help = "The algorithm to compute E[p U q]")
+      .enum<MddCtlChecker.EuStrategy>()
+      .default(MddCtlChecker.EuStrategy.CONSTRAINED_SATURATION)
+
+  override fun doRun() {
+    val solverFactory = SolverManager.resolveSolverFactory(solver)
+    // the XSTS prop block is irrelevant for CTL, but the grammar requires one
+    val xsts = inputOptions.loadXsts(defaultProperty = "true")
+    val monolithicExpr = XstsToMonolithicAdapter(xsts).monolithicExpr
+    val propertyText =
+      ctlProperty?.readText()
+        ?: ctlExpression
+        ?: throw IllegalArgumentException(
+          "Missing CTL property: use --ctl-property or --ctl-expression"
+        )
+    val formula = CtlParser.parse(propertyText, monolithicExpr.vars)
+    val sw = Stopwatch.createStarted()
+    val result: SafetyResult<MddProof, Trace<ExplState, ExprAction>> =
+      SolverPool(solverFactory).use { solverPool ->
+        val checker =
+          MddCtlChecker(
+            monolithicExpr,
+            solverPool,
+            logger,
+            lookAheadStrategy = lookAheadStrategy,
+            euStrategy = euStrategy,
+          )
+        if (checker.isSatisfied(formula)) SafetyResult.safe(MddProof.of(checker.stateSpace))
+        else
+          SafetyResult.unsafe(
+            Trace.of(listOf(ExplState.top()), listOf()),
+            MddProof.of(checker.stateSpace),
+          )
+      }
+    sw.stop()
+    printBenchmarkResult(result, xsts, sw.elapsed(TimeUnit.MILLISECONDS))
+  }
+}

--- a/subprojects/xsts/xsts-cli/src/main/kotlin/hu/bme/mit/theta/xsts/cli/XstsCliHeader.kt
+++ b/subprojects/xsts/xsts-cli/src/main/kotlin/hu/bme/mit/theta/xsts/cli/XstsCliHeader.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2025 Budapest University of Technology and Economics
+ *  Copyright 2026 Budapest University of Technology and Economics
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/subprojects/xsts/xsts-cli/src/main/kotlin/hu/bme/mit/theta/xsts/cli/XstsCliHeader.kt
+++ b/subprojects/xsts/xsts-cli/src/main/kotlin/hu/bme/mit/theta/xsts/cli/XstsCliHeader.kt
@@ -20,7 +20,7 @@ import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.enum
-import hu.bme.mit.theta.analysis.algorithm.mdd.MddChecker
+import hu.bme.mit.theta.analysis.algorithm.mdd.fixedpoint.IterationStrategy
 import hu.bme.mit.theta.common.table.BasicTableWriter
 
 class XstsCliHeader : CliktCommand(name = "header") {
@@ -37,10 +37,10 @@ class XstsCliHeader : CliktCommand(name = "header") {
 
   private val algorithm: Algorithm by
     option(help = "The algorithm to print the header for").enum<Algorithm>().required()
-  private val iterationStrategy: MddChecker.IterationStrategy by
+  private val iterationStrategy: IterationStrategy by
     option(help = "The state space generation algorithm for symbolic checking")
-      .enum<MddChecker.IterationStrategy>()
-      .default(MddChecker.IterationStrategy.GSAT)
+      .enum<IterationStrategy>()
+      .default(IterationStrategy.GSAT)
 
   override fun run() {
     when (algorithm) {
@@ -104,17 +104,11 @@ class XstsCliHeader : CliktCommand(name = "header") {
         "unionHitCount",
       )
       .forEach(writer::cell)
-    if (
-      iterationStrategy in
-        setOf(MddChecker.IterationStrategy.GSAT, MddChecker.IterationStrategy.SAT)
-    ) {
+    if (iterationStrategy in setOf(IterationStrategy.GSAT, IterationStrategy.SAT)) {
       listOf("saturateCacheSize", "saturateQueryCount", "saturateHitCount").forEach(writer::cell)
     }
     listOf("relProdCacheSize", "relProdQueryCount", "relProdHitCount").forEach(writer::cell)
-    if (
-      iterationStrategy in
-        setOf(MddChecker.IterationStrategy.GSAT, MddChecker.IterationStrategy.SAT)
-    ) {
+    if (iterationStrategy in setOf(IterationStrategy.GSAT, IterationStrategy.SAT)) {
       listOf("saturatedNodeCount").forEach(writer::cell)
     }
   }

--- a/subprojects/xsts/xsts-cli/src/main/kotlin/hu/bme/mit/theta/xsts/cli/XstsCliMain.kt
+++ b/subprojects/xsts/xsts-cli/src/main/kotlin/hu/bme/mit/theta/xsts/cli/XstsCliMain.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2025 Budapest University of Technology and Economics
+ *  Copyright 2026 Budapest University of Technology and Economics
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/subprojects/xsts/xsts-cli/src/main/kotlin/hu/bme/mit/theta/xsts/cli/XstsCliMain.kt
+++ b/subprojects/xsts/xsts-cli/src/main/kotlin/hu/bme/mit/theta/xsts/cli/XstsCliMain.kt
@@ -51,6 +51,7 @@ fun main(args: Array<String>): kotlin.Unit =
       XstsCliLtlCegar(),
       XstsCliBounded(),
       XstsCliMdd(),
+      XstsCliCtl(),
       XstsCliPetrinetMdd(),
       XstsCliChc(),
       XstsCliIC3(),

--- a/subprojects/xsts/xsts-cli/src/main/kotlin/hu/bme/mit/theta/xsts/cli/XstsCliMdd.kt
+++ b/subprojects/xsts/xsts-cli/src/main/kotlin/hu/bme/mit/theta/xsts/cli/XstsCliMdd.kt
@@ -28,6 +28,7 @@ import hu.bme.mit.theta.analysis.algorithm.bounded.orderVars
 import hu.bme.mit.theta.analysis.algorithm.mdd.MddAnalysisStatistics
 import hu.bme.mit.theta.analysis.algorithm.mdd.MddChecker
 import hu.bme.mit.theta.analysis.algorithm.mdd.expressionnode.MddExpressionRepresentation
+import hu.bme.mit.theta.analysis.algorithm.mdd.fixedpoint.IterationStrategy
 import hu.bme.mit.theta.common.logging.Logger
 import hu.bme.mit.theta.core.decl.VarDecl
 import hu.bme.mit.theta.solver.SolverManager
@@ -49,10 +50,10 @@ class XstsCliMdd :
     option("--dump-ordering", help = "Dump the computed variable ordering to <model>.ordering")
       .flag()
 
-  private val iterationStrategy: MddChecker.IterationStrategy by
+  private val iterationStrategy: IterationStrategy by
     option(help = "The state space enumeration algorithm to use")
-      .enum<MddChecker.IterationStrategy>()
-      .default(MddChecker.IterationStrategy.GSAT)
+      .enum<IterationStrategy>()
+      .default(IterationStrategy.GSAT)
 
   private val lookAheadStrategy: MddExpressionRepresentation.MddToExprStrategy by
     option(help = "The MDD to expression conversion strategy")

--- a/subprojects/xsts/xsts-cli/src/main/kotlin/hu/bme/mit/theta/xsts/cli/XstsCliPetrinetMdd.kt
+++ b/subprojects/xsts/xsts-cli/src/main/kotlin/hu/bme/mit/theta/xsts/cli/XstsCliPetrinetMdd.kt
@@ -29,7 +29,6 @@ import hu.bme.mit.delta.mdd.LatticeDefinition
 import hu.bme.mit.delta.mdd.MddInterpreter
 import hu.bme.mit.delta.mdd.MddVariableDescriptor
 import hu.bme.mit.theta.analysis.algorithm.mdd.MddAnalysisStatistics
-import hu.bme.mit.theta.analysis.algorithm.mdd.MddChecker
 import hu.bme.mit.theta.analysis.algorithm.mdd.fixedpoint.*
 import hu.bme.mit.theta.common.logging.Logger
 import hu.bme.mit.theta.common.stopwatch.Stopwatch
@@ -60,10 +59,10 @@ class XstsCliPetrinetMdd :
       .flag()
   private val id: String by
     option(help = "ID of the input model. Used for symbolic output").default("")
-  private val iterationStrategy: MddChecker.IterationStrategy by
+  private val iterationStrategy: IterationStrategy by
     option(help = "The state space enumeration algorithm to use")
-      .enum<MddChecker.IterationStrategy>()
-      .default(MddChecker.IterationStrategy.GSAT)
+      .enum<IterationStrategy>()
+      .default(IterationStrategy.GSAT)
   private val dependencyOutput by PetrinetDependencyOutputOptions()
 
   private fun loadOrdering(petriNet: PetriNet): List<Place> =
@@ -97,12 +96,7 @@ class XstsCliPetrinetMdd :
       JavaMddFactory.getDefault().createMddVariableOrder(LatticeDefinition.forSets())
     effectiveOrdering.forEach { variableOrder.createOnTop(MddVariableDescriptor.create(it)) }
     val ssgTimer = Stopwatch.createStarted()
-    val provider: StateSpaceEnumerationProvider =
-      when (iterationStrategy) {
-        MddChecker.IterationStrategy.BFS -> BfsProvider(variableOrder)
-        MddChecker.IterationStrategy.SAT -> SimpleSaturationProvider(variableOrder)
-        MddChecker.IterationStrategy.GSAT -> GeneralizedSaturationProvider(variableOrder)
-      }
+    val provider: StateSpaceEnumerationProvider = iterationStrategy.createProvider(variableOrder)
     val stateSpace =
       provider.compute(
         system.initializer,
@@ -141,17 +135,11 @@ class XstsCliPetrinetMdd :
           unionProvider.hitCount,
         )
         .forEach(writer::cell)
-      if (
-        iterationStrategy in
-          setOf(MddChecker.IterationStrategy.GSAT, MddChecker.IterationStrategy.SAT)
-      ) {
+      if (iterationStrategy in setOf(IterationStrategy.GSAT, IterationStrategy.SAT)) {
         listOf(provider.cacheSize, provider.queryCount, provider.hitCount).forEach(writer::cell)
       }
       listOf(provider.cacheSize, provider.queryCount, provider.hitCount).forEach(writer::cell)
-      if (
-        iterationStrategy in
-          setOf(MddChecker.IterationStrategy.GSAT, MddChecker.IterationStrategy.SAT)
-      ) {
+      if (iterationStrategy in setOf(IterationStrategy.GSAT, IterationStrategy.SAT)) {
         val collector: MutableSet<MddNode> = mutableSetOf()
         provider.clear()
         listOf(collector.size).forEach(writer::cell)

--- a/subprojects/xsts/xsts-cli/src/main/kotlin/hu/bme/mit/theta/xsts/cli/optiongroup/InputOptions.kt
+++ b/subprojects/xsts/xsts-cli/src/main/kotlin/hu/bme/mit/theta/xsts/cli/optiongroup/InputOptions.kt
@@ -85,11 +85,11 @@ class InputOptions :
 
   fun getPetrinetProperty(): PropType = pnProperty ?: PropType.fromFilename(property)
 
-  fun loadXsts(): XSTS {
+  fun loadXsts(defaultProperty: String? = null): XSTS {
+    val inlineProp = inlineProperty ?: defaultProperty
     val propertyStream =
       property?.inputStream()
-        ?: if (inlineProperty != null)
-          ByteArrayInputStream("prop { $inlineProperty }".toByteArray())
+        ?: if (inlineProp != null) ByteArrayInputStream("prop { $inlineProp }".toByteArray())
         else null
     if (isPnml()) {
       val petriNet = XMLPnmlToPetrinet.parse(model.absolutePath, initialmarking)


### PR DESCRIPTION
- Symbolic CTL model checking over the MDD backend via `MddCtlChecker` (`EX`, `EU`, `EG`, plus derived CTL ops).
- Constrained-saturation support for `EU` through `AndNextStateDescriptor`, this means we have two different algorithms for `EU`
- New `common/ctl` module with ANTLR grammar + parser
