### PR TITLE
Archive timestamp fix

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,7 +47,7 @@ buildscript {
 
 allprojects {
     group = "hu.bme.mit.theta"
-    version = "7.2.4"
+    version = "7.2.5"
 
     apply(from = rootDir.resolve("gradle/shared-with-buildSrc/mirrors.gradle.kts"))
 }

--- a/buildSrc/src/main/kotlin/archive-packaging.gradle.kts
+++ b/buildSrc/src/main/kotlin/archive-packaging.gradle.kts
@@ -155,6 +155,7 @@ afterEvaluate {
 		tasks.register<Zip>(taskName) {
 			group = "distribution"
 			description = "Create $toolName binary archive"
+			isPreserveFileTimestamps = true
 
 			// Dependencies using providers
 			dependsOn(downloadLibsProvider)

--- a/buildSrc/src/main/kotlin/archive-packaging.gradle.kts
+++ b/buildSrc/src/main/kotlin/archive-packaging.gradle.kts
@@ -40,6 +40,11 @@ open class ArchivePackagingExtension {
 
 val packagingExt = extensions.create<ArchivePackagingExtension>("archivePackaging")
 
+// TODO simplify when https://github.com/gradle/gradle/issues/13121 is resolved
+interface InjectedExecOps {
+	@get:Inject val execOps: ExecOperations
+}
+
 afterEvaluate {
 	if (packagingExt.variants.isEmpty()) return@afterEvaluate
 
@@ -97,6 +102,8 @@ afterEvaluate {
 			tasks.register(installSolversTaskName) {
 				group = "distribution"
 				description = "Install solvers for $toolName archive"
+
+				val injected = project.objects.newInstance<InjectedExecOps>()
 				
 				// Depend on smtlib-cli jar
 				if (includeSolverCli && hasSolverCli) {
@@ -125,23 +132,17 @@ afterEvaluate {
 					solvers.forEach { solver ->
 						println("Installing solver: $solver into ${solversDir.path}")
 						try {
-							val process = ProcessBuilder(
-								"java", "-jar", smtlibJarFile.absolutePath,
-								"--home", solversDir.absolutePath,
-								"install", solver,
-							).redirectErrorStream(true).start()
-							
-							val output = process.inputStream.bufferedReader().readText()
-							val exitCode = process.waitFor()
-							
-							if (exitCode != 0) {
-								println("Failed to install solver $solver (exit code: $exitCode)")
-								println(output)
+							val result = injected.execOps.javaexec {
+								systemProperties(System.getProperties().mapKeys { it.key.toString() })
+								classpath(smtlibJarFile.absolutePath)
+								args("--home", solversDir.absolutePath, "install", solver)
+								errorOutput = standardOutput
+							}
+
+							if (result.exitValue != 0) {
+								println("Failed to install solver $solver (exit code: ${result.exitValue})")
 							} else {
 								println("Successfully installed: $solver")
-								if (output.isNotBlank()) {
-									println(output)
-								}
 							}
 						} catch (e: Exception) {
 							println("Error installing solver $solver: ${e.message}")


### PR DESCRIPTION
Fixes the issue with files in the artifact having their timestamps removed. Adds the options to configure what platform and architecture the artifact should be built for, using the  `-Dos.name` and `-Dos.arch` flags with the corresponding `buildArchive` task.