### PR TITLE
Fix unsound memory model in DereferenceToArrayPass

### DIFF
--- a/subprojects/xcfa/xcfa/src/main/java/hu/bme/mit/theta/xcfa/passes/DereferenceToArrayPass.kt
+++ b/subprojects/xcfa/xcfa/src/main/java/hu/bme/mit/theta/xcfa/passes/DereferenceToArrayPass.kt
@@ -58,16 +58,40 @@ private typealias ArrayType2D = ArrayType<out Type, ArrayType<out Type, out Type
  * where arrays is the global array variable corresponding to the types of array, offset, and
  * element. Upon each write to the memory location, the corresponding global array is also updated
  * to reflect the change.
+ *
+ * The array is chosen by the types alone. It must not also depend on whether the pointer expression
+ * happens to be a global variable: the same address can be reached through a global pointer at one
+ * place and through a local one at another, and putting those accesses in different arrays would
+ * make them stop aliasing, so a write through one would be invisible to a read through the other.
+ * Whether *any* dereference of a type triple is global only decides how the array starts out: zero,
+ * as C guarantees for global variables, or unconstrained.
  */
 class DereferenceToArrayPass : ProcedurePass {
 
   private lateinit var arraysByType:
     Map<Tuple4<Type, Type, Type, Boolean>, VarDecl<out ArrayType2D>>
 
-  /** Maps a dereference to an identifying type key */
-  private fun <A : Type, O : Type, T : Type> Dereference<A, O, T>.getTypeKey(
+  /**
+   * How the array of a type triple starts out: zero when the program dereferences a global pointer
+   * of these types anywhere, unconstrained otherwise.
+   */
+  private lateinit var globalByTypes: Map<Triple<Type, Type, Type>, Boolean>
+
+  /** The types of a dereference, which alone select its array. */
+  private fun <A : Type, O : Type, T : Type> Dereference<A, O, T>.types():
+    Triple<Type, Type, Type> = Triple(array.type, offset.type, type)
+
+  /** The array key of a dereference: its types, plus how that array is initialized. */
+  private fun <A : Type, O : Type, T : Type> Dereference<A, O, T>.getTypeKey():
+    Tuple4<Type, Type, Type, Boolean> {
+    val t = types()
+    return Tuple4.of(t.first, t.second, t.third, globalByTypes[t]!!)
+  }
+
+  /** Whether this single dereference goes through a global pointer. */
+  private fun <A : Type, O : Type, T : Type> Dereference<A, O, T>.isGlobalDeref(
     xcfa: XcfaBuilder
-  ): Tuple4<Type, Type, Type, Boolean> {
+  ): Boolean {
     val globalVars = xcfa.getVars().map { it.wrappedVar }
     val isGlobal =
       (array as? RefExpr<*>)?.decl in globalVars ||
@@ -81,7 +105,7 @@ class DereferenceToArrayPass : ProcedurePass {
             }
           }
         }
-    return Tuple4.of(array.type, offset.type, type, isGlobal)
+    return isGlobal
   }
 
   /** Returns an array from the pre-generated lookup of types */
@@ -90,7 +114,7 @@ class DereferenceToArrayPass : ProcedurePass {
   ): VarDecl<ArrayType<A, ArrayType<O, T>>> {
     val arrayType = ArrayType.of(array.type, ArrayType.of(offset.type, type))
 
-    return cast(arraysByType[getTypeKey(xcfa)]!!, arrayType)
+    return cast(arraysByType[getTypeKey()]!!, arrayType)
   }
 
   /** Creates arrays from dereference types */
@@ -127,14 +151,22 @@ class DereferenceToArrayPass : ProcedurePass {
 
   override fun run(builder: XcfaProcedureBuilder): XcfaProcedureBuilder {
     if (!::arraysByType.isInitialized) {
-      val arrays = mutableMapOf<Tuple4<Type, Type, Type, Boolean>, VarDecl<out ArrayType2D>>()
-      val types = mutableSetOf<Tuple4<Type, Type, Type, Boolean>>()
+      // one array per type triple; a triple starts out zeroed when any of its dereferences is global
+      val global = mutableMapOf<Triple<Type, Type, Type>, Boolean>()
       builder.parent.getProcedures().forEach { p ->
         p.getEdges().forEach { e ->
-          e.label.dereferences.forEach { deref -> types.add(deref.getTypeKey(builder.parent)) }
+          e.label.dereferences.forEach { deref ->
+            val t = deref.types()
+            global[t] = (global[t] ?: false) || deref.isGlobalDeref(builder.parent)
+          }
         }
       }
-      types.forEach { arrays[it] = createArray(it, builder.parent) }
+      globalByTypes = global
+      val arrays = mutableMapOf<Tuple4<Type, Type, Type, Boolean>, VarDecl<out ArrayType2D>>()
+      global.forEach { (t, isGlobal) ->
+        val key = Tuple4.of(t.first, t.second, t.third, isGlobal)
+        arrays[key] = createArray(key, builder.parent)
+      }
       arraysByType = arrays
     }
 


### PR DESCRIPTION
## The problem

`DereferenceToArrayPass` stores memory in one global array per key
`(array type, offset type, element type, isGlobal)`.

`isGlobal` is a syntactic property of the *pointer expression*: whether it is a global variable, or is
assigned to a global one in an init procedure. It is computed per dereference, so the same address can
be classified differently at different places in the program.

Because it is part of the key, it does not only choose how the array is initialized, it also chooses
*which* array is used. Two dereferences of the same address then land in different arrays and stop
aliasing: a write through one is invisible to a read through the other. One array is zero-initialized
and the other havoc-initialized, so the usual effect is a read that keeps returning 0.

This removes behaviour from the model, so every backend built on the monolithic encoding (BMC, KIND,
IMC, MDD, MDD_CEGAR) can answer **Safe on a program that is genuinely unsafe**.

## How it shows up

`ReferenceElimination` rewrites every access to an address-taken global `y` into `*(y*)`, where `y*` is
a global pointer variable holding y's address. A program that also reaches the same location through a
local pointer, e.g.

```c
p = &y;
...
x = *p;
```

writes into the global array and reads from the non-global one, so the read can never see the write.

The SV-COMP concurrency weak-memory tasks do exactly this (`__unbuffered_p0_EAX$read_delayed_var = &y`
and a later `*__unbuffered_p0_EAX$read_delayed_var`). On
`safe006_rmo.oepc_rmo.opt-thin000_rmo.oepc_rmo.opt.i`, expected verdict `false`:

| configuration | verdict |
|---|---|
| `--backend CEGAR --domain PRED_CART --por SPOR` | Unsafe, 25-step counterexample, 11 s |
| `--backend BMC` before this change | **Safe, 82 s** |
| `--backend BMC` after this change | Unsafe, 20-step counterexample, 37 s |

The other passes of the monolithic pipeline were ruled out first by bisecting them (LBE, aggressive
LBE collapsing of non-concurrent edges, `RemoveUnnecessaryAtomicBlocksPass`, `EliminateSelfLoops`); none
of them changes the verdict.

## The fix

The array is selected by the types alone. Whether *any* dereference of a type triple is global only
decides how that array starts out: zeroed, as C guarantees for globals, or unconstrained. This keeps
the behaviour intended by 788eb58c6 ("fix initial value of arrays (memory garbage for local arrays)")
while no longer partitioning memory by it.

## Testing

- `theta-xcfa` and `theta-xcfa-analysis` test suites pass.
- Validated on 11 SV-COMP concurrency tasks with `MDD_CEGAR`: previously wrong Safe answers now give a
  counterexample or no verdict, and 4 expected-`true` plus 3 expected-`false` tasks are unchanged. No
  wrong verdict remained in the sample.
- A full 726-task sw-concurrency run against the pre-fix baseline is in progress.

## Note

The bug is easy to miss in review because the change that introduced it reads as being purely about
initial values, which it is, except that putting the flag in the key also silently repartitions
memory. It stayed hidden because the affected tasks used to time out on every monolithic backend
instead of producing a verdict.