### PR TITLE
MDD fixes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -86,7 +86,7 @@ buildscript {
 
 allprojects {
     group = "hu.bme.mit.theta"
-    version = "8.0.0"
+    version = "8.1.0"
 
     apply(from = rootDir.resolve("gradle/shared-with-buildSrc/mirrors.gradle.kts"))
 }

--- a/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/bounded/ImplicitPredicateAbstractor.kt
+++ b/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/bounded/ImplicitPredicateAbstractor.kt
@@ -24,31 +24,48 @@ import hu.bme.mit.theta.analysis.pred.PredState
 import hu.bme.mit.theta.core.decl.Decl
 import hu.bme.mit.theta.core.decl.Decls
 import hu.bme.mit.theta.core.decl.VarDecl
+import hu.bme.mit.theta.core.model.ImmutableValuation
 import hu.bme.mit.theta.core.model.Valuation
 import hu.bme.mit.theta.core.type.Expr
+import hu.bme.mit.theta.core.type.LitExpr
+import hu.bme.mit.theta.core.type.Type
+import hu.bme.mit.theta.core.type.abstracttype.AbstractExprs.Eq
 import hu.bme.mit.theta.core.type.anytype.Exprs
 import hu.bme.mit.theta.core.type.booltype.BoolExprs
 import hu.bme.mit.theta.core.type.booltype.BoolLitExpr
 import hu.bme.mit.theta.core.type.booltype.BoolType
+import hu.bme.mit.theta.core.type.booltype.FalseExpr
 import hu.bme.mit.theta.core.type.booltype.IffExpr
 import hu.bme.mit.theta.core.type.booltype.SmartBoolExprs.And
 import hu.bme.mit.theta.core.type.booltype.SmartBoolExprs.Not
+import hu.bme.mit.theta.core.type.booltype.SmartBoolExprs.Or
 import hu.bme.mit.theta.core.utils.ExprUtils
+import hu.bme.mit.theta.core.utils.PathUtils
+import hu.bme.mit.theta.core.utils.indexings.VarIndexing
 import hu.bme.mit.theta.core.utils.indexings.VarIndexingFactory
 
-/** Implicit predicate abstraction over a [MonolithicExpr]. */
+/** Implicit predicate abstraction over a [MonolithicExpr], split by connected literals. */
 class ImplicitPredicateAbstractor(private val concreteModel: MonolithicExpr) {
 
   private val predToLiteral = LinkedHashMap<Expr<BoolType>, VarDecl<BoolType>>()
   private val literalToPredMap = LinkedHashMap<Decl<*>, Expr<BoolType>>()
   private lateinit var currentPrec: PredPrec
+  private var groupTransitions: List<List<Int>> = emptyList()
+
+  private val transitionVars: List<Set<VarDecl<*>>> by lazy {
+    concreteModel.split.map(::readWriteVars)
+  }
+
+  private val unfoldedTransitions: List<Expr<BoolType>> by lazy {
+    concreteModel.split.map { PathUtils.unfold(it, VarIndexingFactory.indexing(0)) }
+  }
 
   /** Builds the abstract [MonolithicExpr] for [prec]; reports which literals were newly created. */
   fun abstractModel(prec: PredPrec): AbstractionResult {
     currentPrec = prec
-    val lambdaList = ArrayList<IffExpr>()
-    val lambdaPrimeList = ArrayList<IffExpr>()
-    val activationLiterals = ArrayList<VarDecl<*>>()
+    val lambda = LinkedHashMap<VarDecl<BoolType>, Expr<BoolType>>()
+    val lambdaPrime = LinkedHashMap<VarDecl<BoolType>, Expr<BoolType>>()
+    val activationLiterals = ArrayList<VarDecl<BoolType>>()
     val newLiterals = ArrayList<VarDecl<BoolType>>()
 
     // predicates over only ctrl vars get no literal
@@ -63,29 +80,59 @@ class ImplicitPredicateAbstractor(private val concreteModel: MonolithicExpr) {
             lit
           }
         activationLiterals.add(v)
-        lambdaList.add(IffExpr.of(v.ref, expr))
-        lambdaPrimeList.add(
+        lambda[v] = IffExpr.of(v.ref, expr)
+        lambdaPrime[v] =
           BoolExprs.Iff(
             Exprs.Prime(v.ref),
             ExprUtils.applyPrimes(expr, concreteModel.transOffsetIndex),
           )
-        )
       }
 
-    // transOffsetIndex: default offset 1, incremented only over non-ctrl concrete vars
     var indexingBuilder = VarIndexingFactory.indexingBuilder(1)
-    concreteModel.vars
-      .filter { it !in concreteModel.ctrlVars }
-      .forEach { decl ->
-        repeat(concreteModel.transOffsetIndex[decl]) { indexingBuilder = indexingBuilder.inc(decl) }
+    concreteModel.vars.forEach { decl ->
+      val offset = concreteModel.transOffsetIndex[decl]
+      if (decl !in concreteModel.ctrlVars) {
+        repeat(offset) { indexingBuilder = indexingBuilder.inc(decl) }
+      } else if (offset > 1) {
+        repeat(offset - 1) { indexingBuilder = indexingBuilder.inc(decl) }
       }
+    }
     val transOffsetIndex = indexingBuilder.build()
+
+    val literalVars = activationLiterals.associateWith { ExprUtils.getVars(literalToPredMap[it]!!) }
+    val groups = LinkedHashMap<Set<VarDecl<BoolType>>, MutableList<Int>>()
+    concreteModel.split.indices.forEach { i ->
+      // literals sharing a variable with the transition or with another connected literal
+      var reached: Set<VarDecl<*>> = transitionVars[i]
+      do {
+        val before = reached.size
+        reached =
+          reached + literalVars.values.filter { vars -> vars.any { it in reached } }.flatten()
+      } while (reached.size > before)
+      val connected =
+        activationLiterals.filter { literalVars[it]!!.any { v -> v in reached } }.toSet()
+      groups.getOrPut(connected) { ArrayList() }.add(i)
+    }
+    groupTransitions = groups.values.map { it.toList() }
+    val splits =
+      groups.map { (connected, transitions) ->
+        val identity = activationLiterals.filter { it !in connected }
+        And(
+          listOf(
+            And(connected.map { lambda[it]!! }),
+            And(connected.map { lambdaPrime[it]!! }),
+            Or(transitions.map { concreteModel.split[it] }),
+            And(identity.map { Eq(Exprs.Prime(it.ref), it.ref) }),
+          )
+        )
+      }
+    val allLambda = And(lambda.values)
 
     val model =
       MonolithicExpr(
-        initExpr = And(And(lambdaList), concreteModel.initExpr),
-        transExpr = And(And(lambdaList), And(lambdaPrimeList), concreteModel.transExpr),
-        propExpr = Not(And(And(lambdaList), Not(concreteModel.propExpr))),
+        initExpr = And(allLambda, concreteModel.initExpr),
+        transExpr = if (splits.size == 1) splits[0] else Or(splits),
+        propExpr = Not(And(allLambda, Not(concreteModel.propExpr))),
         transOffsetIndex = transOffsetIndex,
         vars = activationLiterals + concreteModel.ctrlVars,
         ctrlVars = concreteModel.ctrlVars,
@@ -104,13 +151,20 @@ class ImplicitPredicateAbstractor(private val concreteModel: MonolithicExpr) {
                 affectedCtrlVars + affectedActivationLiterals
             }
           },
+        explicitSplit = splits,
       )
     return AbstractionResult(model, newLiterals)
   }
 
-  /** Maps an abstract trace to a predicate trace under the prec of the last [abstractModel]. */
-  fun toPredTrace(trace: Trace<ExplState, ExprAction>): Trace<PredState, ExprAction> =
-    Trace.of(trace.states.map(this::toPredState), trace.actions.map { concreteModel.action() })
+  fun toPredTrace(trace: Trace<ExplState, ExprAction>): Trace<PredState, ExprAction> {
+    val actions =
+      trace.actions.mapIndexed { k, action ->
+        if (action is MonolithicExprSplitAction && action.index in groupTransitions.indices)
+          concreteAction(groupTransitions[action.index], trace.states[k], trace.states[k + 1])
+        else concreteModel.action()
+      }
+    return Trace.of(trace.states.map(this::toPredState), actions)
+  }
 
   private fun toPredState(valuation: Valuation): PredState =
     PredState.of(
@@ -121,9 +175,50 @@ class ImplicitPredicateAbstractor(private val concreteModel: MonolithicExpr) {
         }
       }
     )
+
+  private fun concreteAction(
+    candidates: List<Int>,
+    source: ExplState,
+    target: ExplState,
+  ): ExprAction {
+    val enabled = candidates.filter { ctrlConsistent(it, source.`val`, target.`val`) }
+    val chosen = if (enabled.isEmpty()) candidates else enabled
+    if (chosen.size == 1) return concreteModel.splitAction(chosen[0])
+    val expr = Or(chosen.map { concreteModel.split[it] })
+    return object : ExprAction {
+      override fun toExpr(): Expr<BoolType> = expr
+
+      override fun nextIndexing(): VarIndexing = concreteModel.transOffsetIndex
+    }
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  private fun ctrlConsistent(transition: Int, source: Valuation, target: Valuation): Boolean {
+    val builder = ImmutableValuation.builder()
+    for (ctrl in concreteModel.ctrlVars) {
+      source.eval(ctrl).ifPresent {
+        builder.put(ctrl.getConstDecl(0) as Decl<Type>, it as LitExpr<Type>)
+      }
+      target.eval(ctrl).ifPresent {
+        builder.put(
+          ctrl.getConstDecl(concreteModel.transOffsetIndex[ctrl]) as Decl<Type>,
+          it as LitExpr<Type>,
+        )
+      }
+    }
+    return ExprUtils.simplify(unfoldedTransitions[transition], builder.build()) !is FalseExpr
+  }
+
+  // a havoc leaves no constraint, so a variable the transition does not frame counts as written
+  private fun readWriteVars(transition: Expr<BoolType>): Set<VarDecl<*>> {
+    val mentioned = ExprUtils.getVars(transition)
+    val havocked =
+      concreteModel.vars.filter {
+        it !in concreteModel.ctrlVars && concreteModel.transOffsetIndex[it] > 0 && it !in mentioned
+      }
+    val event = MonolithicExprEvent(transition, concreteModel.transOffsetIndex)
+    return event.getAffectedVars().toSet() + havocked
+  }
 }
 
-data class AbstractionResult(
-  val model: MonolithicExpr,
-  val newLiterals: List<VarDecl<BoolType>>, // creation order
-)
+data class AbstractionResult(val model: MonolithicExpr, val newLiterals: List<VarDecl<BoolType>>)

--- a/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/bounded/MonolithicExpr.kt
+++ b/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/bounded/MonolithicExpr.kt
@@ -38,8 +38,9 @@ constructor(
   val ctrlVars: Collection<VarDecl<*>> = listOf(),
   val events: List<Event<VarDecl<*>>> =
     splitTransExpr(transExpr).map { MonolithicExprEvent(it, transOffsetIndex) },
+  val explicitSplit: List<Expr<BoolType>>? = null,
 ) {
-  val split: List<Expr<BoolType>> by lazy { splitTransExpr(transExpr) }
+  val split: List<Expr<BoolType>> by lazy { explicitSplit ?: splitTransExpr(transExpr) }
 }
 
 fun MonolithicExpr.action() =

--- a/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/mdd/MddChecker.kt
+++ b/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/mdd/MddChecker.kt
@@ -29,6 +29,7 @@ import hu.bme.mit.theta.analysis.algorithm.mdd.ansd.AbstractNextStateDescriptor
 import hu.bme.mit.theta.analysis.algorithm.mdd.ansd.impl.*
 import hu.bme.mit.theta.analysis.algorithm.mdd.fixedpoint.*
 import hu.bme.mit.theta.analysis.algorithm.mdd.node.expression.ExprLatticeDefinition
+import hu.bme.mit.theta.analysis.algorithm.mdd.node.expression.MddApproximation
 import hu.bme.mit.theta.analysis.algorithm.mdd.node.expression.MddExplicitRepresentationExtractor
 import hu.bme.mit.theta.analysis.algorithm.mdd.node.expression.MddExpressionRepresentation
 import hu.bme.mit.theta.analysis.algorithm.mdd.node.expression.MddExpressionTemplate
@@ -69,6 +70,7 @@ constructor(
     MddExpressionRepresentation.MddToExprStrategy.NODE_LEVEL,
   private val solverMeasurements: Boolean = false,
   private val traceSearch: TraceSearch = TraceSearch.DFS,
+  private val approximation: MddApproximation = MddApproximation.exact(),
 ) : SafetyChecker<MddProof, Trace<ExplState, ExprAction>, UnitPrec> {
 
   override fun check(prec: UnitPrec?): SafetyResult<MddProof, Trace<ExplState, ExprAction>> {
@@ -78,6 +80,8 @@ constructor(
     val mddGraph2 = JavaMddFactory.getDefault().createMddGraph(ExprLatticeDefinition.forExpr())
     mddGraph.setAttribute(MddExpressionRepresentation.LOOK_AHEAD, lookAheadStrategy)
     mddGraph2.setAttribute(MddExpressionRepresentation.LOOK_AHEAD, lookAheadStrategy)
+    mddGraph.setAttribute(MddExpressionRepresentation.APPROXIMATION, approximation)
+    mddGraph2.setAttribute(MddExpressionRepresentation.APPROXIMATION, approximation)
 
     val stateOrder = JavaMddFactory.getDefault().createMddVariableOrder(mddGraph)
     val transOrder = JavaMddFactory.getDefault().createMddVariableOrder(mddGraph2)
@@ -199,6 +203,11 @@ constructor(
     if (solverMeasurements) {
       stateSpaceProvider.clear()
       structuralRerun(transNodes, transSig, initNode, stateSig, ssgTime.elapsedMillis())
+    }
+
+    if (violatingSize == 0L && approximation.isUnderApproximated) {
+      logger.write(Logger.Level.RESULT, "Cannot justify the verdict under %s\n", approximation)
+      return SafetyResult.unknown(statistics)
     }
 
     val result: SafetyResult<MddProof, Trace<ExplState, ExprAction>>

--- a/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/mdd/cegar/MddCegarChecker.kt
+++ b/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/mdd/cegar/MddCegarChecker.kt
@@ -26,9 +26,7 @@ import hu.bme.mit.theta.analysis.algorithm.SafetyChecker
 import hu.bme.mit.theta.analysis.algorithm.SafetyResult
 import hu.bme.mit.theta.analysis.algorithm.bounded.ImplicitPredicateAbstractor
 import hu.bme.mit.theta.analysis.algorithm.bounded.MonolithicExpr
-import hu.bme.mit.theta.analysis.algorithm.bounded.action
 import hu.bme.mit.theta.analysis.algorithm.bounded.orderVars
-import hu.bme.mit.theta.analysis.algorithm.mdd.ansd.impl.AndNextStateDescriptor
 import hu.bme.mit.theta.analysis.algorithm.mdd.ansd.impl.MddNodeNextStateDescriptor
 import hu.bme.mit.theta.analysis.algorithm.mdd.ansd.impl.MddNodePostcondition
 import hu.bme.mit.theta.analysis.algorithm.mdd.ansd.impl.OnTheFlyReachabilityNextStateDescriptor
@@ -58,7 +56,9 @@ import hu.bme.mit.theta.common.stopwatch.Stopwatch
 import hu.bme.mit.theta.core.decl.Decl
 import hu.bme.mit.theta.core.decl.VarDecl
 import hu.bme.mit.theta.core.type.Expr
+import hu.bme.mit.theta.core.type.abstracttype.AbstractExprs.Eq
 import hu.bme.mit.theta.core.type.booltype.BoolType
+import hu.bme.mit.theta.core.type.booltype.SmartBoolExprs.And
 import hu.bme.mit.theta.core.type.booltype.SmartBoolExprs.Not
 import hu.bme.mit.theta.core.utils.ExprUtils
 import hu.bme.mit.theta.core.utils.PathUtils
@@ -74,70 +74,69 @@ constructor(
   private val logger: Logger,
   private val traceCheckerFactory: (MonolithicExpr) -> ExprTraceChecker<ItpRefutation>,
   private val iterationStrategy: IterationStrategy = IterationStrategy.GSAT,
+  // the property alone; an init predicate would connect every literal to every transition
   private val initPrec: (MonolithicExpr) -> PredPrec = { model ->
-    PredPrec.of(listOf(model.propExpr, model.initExpr))
+    PredPrec.of(listOf(model.propExpr))
   },
   private val precRefiner: PrecRefiner<PredState, ExprAction, PredPrec, ItpRefutation> =
     JoiningPrecRefiner.create(ItpRefToPredPrec(ExprSplitters.atoms())),
-  private val useReachConstraint: Boolean = true,
   private val useOnTheFlyReachability: Boolean = false,
   private val traceTimeout: Long = 10,
   private val lookAheadStrategy: MddExpressionRepresentation.MddToExprStrategy =
     MddExpressionRepresentation.MddToExprStrategy.NONE,
   private val proofStrategy: MddExpressionRepresentation.MddToExprStrategy =
     MddExpressionRepresentation.MddToExprStrategy.NODE_LEVEL,
-  private val traceSearch: TraceSearch = TraceSearch.DFS,
+  private val literalPlacement: LiteralPlacement = LiteralPlacement.FORCE,
+  private val traceSearch: TraceSearch = TraceSearch.BFS,
 ) : SafetyChecker<MddProof, Trace<ExplState, ExprAction>, UnitPrec> {
-
-  init {
-    require(!(useOnTheFlyReachability && useReachConstraint)) {
-      "on-the-fly reachability cannot combine with the reach-set constraint: early termination " +
-        "leaves the constraint unsound"
-    }
-  }
 
   override fun check(prec: UnitPrec?): SafetyResult<MddProof, Trace<ExplState, ExprAction>> {
     val totalTime = Stopwatch.createStarted()
 
-    val orders = CegarOrders(concreteModel)
-    orders.stateOrder.mddGraph.setAttribute(
-      MddExpressionRepresentation.LOOK_AHEAD,
-      lookAheadStrategy,
-    )
-    orders.transOrder.mddGraph.setAttribute(
-      MddExpressionRepresentation.LOOK_AHEAD,
-      lookAheadStrategy,
-    )
+    var orders: CegarOrders? =
+      if (literalPlacement == LiteralPlacement.FORCE) null else newOrders(null)
 
     val abstractor = ImplicitPredicateAbstractor(concreteModel)
     val traceChecker = traceCheckerFactory(concreteModel)
     var currentPrec = initPrec(concreteModel)
-    var prevStateSpace: MddHandle? = null
 
     // one provider for the run: its caches are keyed by (node, descriptor)
-    val provider = iterationStrategy.createProvider(orders.stateOrder)
+    var provider: StateSpaceEnumerationProvider? =
+      orders?.let { iterationStrategy.createProvider(it.stateOrder) }
 
     var totalSolverCalls = 0L
     var i = 0
 
     while (true) {
       i++
-      val (model, newLits) = abstractor.abstractModel(currentPrec)
+      val abstraction = abstractor.abstractModel(currentPrec)
+      val model = abstraction.model
+      val newLits = abstraction.newLiterals
 
-      newLits.forEach(orders::createLevelOnTop)
+      val orderTime = Stopwatch.createStarted()
+      if (literalPlacement == LiteralPlacement.FORCE) {
+        val o = newOrders(model.orderVars())
+        orders = o
+        provider = iterationStrategy.createProvider(o.stateOrder)
+      } else {
+        newLits.forEach { orders!!.createLiteralLevel(it) }
+      }
+      orderTime.stop()
+      val currentOrders = orders!!
+      val currentProvider = provider!!
 
-      val constraint = if (useReachConstraint) prevStateSpace else null
-
-      val iter = runIteration(model, constraint, orders, provider)
+      val iter = runIteration(model, currentOrders, currentProvider)
       totalSolverCalls += iter.relationSolverCalls + iter.saturationSolverCalls
 
       logger.write(
         Logger.Level.MAINSTEP,
-        "CEGAR iteration %d: |prec|=%d, newLiterals=%d, relationChecks=%d, saturationChecks=%d, " +
-          "stateSpace=%d, violating=%d, cacheHit=%d/%d, ssgTime=%dms\n",
+        "CEGAR iteration %d: |prec|=%d, newLiterals=%d, transitions=%d, relationChecks=%d, " +
+          "saturationChecks=%d, stateSpace=%d, violating=%d, cacheHit=%d/%d, ssgTime=%dms, " +
+          "orderTime=%dms\n",
         i,
         currentPrec.preds.size,
         newLits.size,
+        model.split.size,
         iter.relationSolverCalls,
         iter.saturationSolverCalls,
         iter.stateSpaceSize,
@@ -145,6 +144,7 @@ constructor(
         iter.hitCount,
         iter.queryCount,
         iter.ssgTimeMs,
+        orderTime.elapsedMillis(),
       )
 
       if (iter.violatingSize == 0L) {
@@ -156,20 +156,22 @@ constructor(
         )
       }
 
-      checkNotNull(iter.trace) {
-        "CEGAR iteration $i found a violation but trace generation timed out"
-      }
+      val trace =
+        checkNotNull(iter.trace) {
+          "CEGAR iteration $i found a violation but trace generation timed out"
+        }
 
-      val predTrace = abstractor.toPredTrace(iter.trace)
+      val refinementTime = Stopwatch.createStarted()
+      val predTrace = abstractor.toPredTrace(trace)
       val res = traceChecker.check(predTrace)
       if (res.isFeasible) {
         totalTime.stop()
         logSummary(i, totalSolverCalls, totalTime.elapsedMillis())
         val valuations = res.asFeasible().valuations
         val cex =
-          Trace.of(
+          Trace.of<ExplState, ExprAction>(
             valuations.states.map { ExplState.of(it) },
-            valuations.actions.map { concreteModel.action() },
+            valuations.actions.map { it as ExprAction },
           )
         return SafetyResult.unsafe(
           cex,
@@ -177,19 +179,31 @@ constructor(
           statisticsOf(iter, totalTime.elapsedMillis()),
         )
       }
-
-      val refutation = res.asInfeasible().refutation
-      currentPrec = precRefiner.refine(currentPrec, predTrace, refutation)
-      currentPrec =
-        PredPrec.of(
-          currentPrec.preds.filter { pred ->
-            ExprUtils.getVars(pred).any { it !in concreteModel.ctrlVars }
-          }
-        )
-
-      prevStateSpace = iter.stateSpace
+      val refined = precRefiner.refine(currentPrec, predTrace, res.asInfeasible().refutation)
+      refinementTime.stop()
+      val newPrec = PredPrec.of(dataPreds(refined))
+      logger.write(
+        Logger.Level.MAINSTEP,
+        "CEGAR refinement %d: traceStates=%d, checkTime=%dms, newPreds=%d\n",
+        i,
+        trace.states.size,
+        refinementTime.elapsedMillis(),
+        newPrec.preds.size - currentPrec.preds.size,
+      )
+      currentPrec = newPrec
     }
   }
+
+  private fun newOrders(fullOrder: List<VarDecl<*>>?): CegarOrders {
+    val orders = CegarOrders(concreteModel, fullOrder)
+    listOf(orders.stateOrder, orders.transOrder).forEach {
+      it.mddGraph.setAttribute(MddExpressionRepresentation.LOOK_AHEAD, lookAheadStrategy)
+    }
+    return orders
+  }
+
+  private fun dataPreds(prec: PredPrec): List<Expr<BoolType>> =
+    prec.preds.filter { p -> ExprUtils.getVars(p).any { it !in concreteModel.ctrlVars } }
 
   private data class IterationResult(
     val stateSpace: MddHandle,
@@ -206,7 +220,6 @@ constructor(
 
   private fun runIteration(
     model: MonolithicExpr,
-    prevStateSpace: MddHandle?,
     orders: CegarOrders,
     provider: StateSpaceEnumerationProvider,
   ): IterationResult {
@@ -219,13 +232,10 @@ constructor(
     val relSolverBefore = solverPool.checkCount
     val transNodes =
       model.split.map { expr ->
+        val transExpr =
+          And(PathUtils.unfold(expr, VarIndexingFactory.indexing(0)), And(orders.identityExprs))
         transSig.topVariableHandle.checkInNode(
-          MddExpressionTemplate.ofKnownSat(
-            PathUtils.unfold(expr, VarIndexingFactory.indexing(0)),
-            { it as Decl<*> },
-            solverPool,
-            true,
-          )
+          MddExpressionTemplate.ofKnownSat(transExpr, { it as Decl<*> }, solverPool, true)
         )
       }
     val propNode = stateNode(PathUtils.unfold(Not(model.propExpr), 0), stateSig)
@@ -233,17 +243,9 @@ constructor(
 
     val relation =
       OrNextStateDescriptor.create(transNodes.map { MddNodeNextStateDescriptor.of(it) })
-    // lifted under the current top, so the interpreter floats it over the new literal levels
-    val constrained =
-      if (prevStateSpace == null) relation
-      else
-        AndNextStateDescriptor.of(
-          MddNodePostcondition.of(stateSig.topVariableHandle.getHandleFor(prevStateSpace.node)),
-          relation,
-        )
     val nextStates =
-      if (useOnTheFlyReachability) OnTheFlyReachabilityNextStateDescriptor.of(constrained, propNode)
-      else constrained
+      if (useOnTheFlyReachability) OnTheFlyReachabilityNextStateDescriptor.of(relation, propNode)
+      else relation
 
     val satSolverBefore = solverPool.checkCount
     val ssgTime = Stopwatch.createStarted()
@@ -257,7 +259,8 @@ constructor(
     val stateSpaceSize = MddInterpreter.calculateNonzeroCount(stateSpace)
 
     val trace =
-      if (violatingSize != 0L)
+      if (violatingSize == 0L) null
+      else
         generateTrace(
           transNodes,
           transSig,
@@ -268,9 +271,8 @@ constructor(
           model,
           traceTimeout,
           logger,
-          search = traceSearch,
+          traceSearch,
         )
-      else null
 
     return IterationResult(
       stateSpace,
@@ -310,17 +312,23 @@ constructor(
   private fun logSummary(iterations: Int, totalSolverCalls: Long, totalTimeMs: Long) {
     logger.write(
       Logger.Level.MAINSTEP,
-      "CEGAR finished: iterations=%d, totalSolverChecks=%d, totalTime=%dms, reachConstraint=%b\n",
+      "CEGAR finished: iterations=%d, totalSolverChecks=%d, totalTime=%dms\n",
       iterations,
       totalSolverCalls,
       totalTimeMs,
-      useReachConstraint,
     )
   }
 }
 
-/** The state and transition orders: ctrl levels at the bottom, literal levels added on top. */
-private class CegarOrders(concreteModel: MonolithicExpr) {
+/** Where the literal levels go in the MDD orders. */
+enum class LiteralPlacement {
+  TOP,
+  FORCE,
+}
+
+private class CegarOrders(concreteModel: MonolithicExpr, fullOrder: List<VarDecl<*>>? = null) {
+  private val ctrlOffsets: Map<VarDecl<*>, Int> =
+    concreteModel.ctrlVars.associateWith { concreteModel.transOffsetIndex[it] }
 
   val stateOrder: MddVariableOrder =
     JavaMddFactory.getDefault()
@@ -332,20 +340,42 @@ private class CegarOrders(concreteModel: MonolithicExpr) {
       .createMddVariableOrder(
         JavaMddFactory.getDefault().createMddGraph(ExprLatticeDefinition.forExpr())
       )
+  val identityExprs = mutableListOf<Expr<BoolType>>()
 
   init {
-    // createOnTop builds bottom-up: reversed, so the first ctrl var ends up highest
-    concreteModel
-      .orderVars()
-      .filter { it in concreteModel.ctrlVars }
-      .reversed()
-      .forEach(::createLevelOnTop)
+    if (fullOrder != null) {
+      fullOrder.reversed().forEach {
+        if (it in concreteModel.ctrlVars) createLevelOnTop(it) else createLiteralLevel(it)
+      }
+    } else {
+      concreteModel
+        .orderVars()
+        .filter { it in concreteModel.ctrlVars }
+        .reversed()
+        .forEach(::createLevelOnTop)
+    }
   }
 
-  /** Abstract vars (ctrl vars and literals) always have offset 1 in the abstract relation. */
   fun createLevelOnTop(v: VarDecl<*>) {
     stateOrder.createOnTop(MddVariableDescriptor.create(v.getConstDecl(0), 0))
-    transOrder.createOnTop(MddVariableDescriptor.create(v.getConstDecl(1), 0))
+    createTransLevelOnTop(v, ctrlOffsets[v] ?: 1)
+  }
+
+  fun createLiteralLevel(v: VarDecl<*>) {
+    val desc0 = MddVariableDescriptor.create(v.getConstDecl(0), 0)
+    val desc1 = MddVariableDescriptor.create(v.getConstDecl(1), 0)
+    stateOrder.createOnTop(desc0)
+    transOrder.createOnTop(desc1)
+    transOrder.createOnTop(desc0)
+  }
+
+  private fun createTransLevelOnTop(v: VarDecl<*>, targetIndex: Int) {
+    if (targetIndex > 0) {
+      transOrder.createOnTop(MddVariableDescriptor.create(v.getConstDecl(targetIndex), 0))
+    } else {
+      transOrder.createOnTop(MddVariableDescriptor.create(v.getConstDecl(1), 0))
+      identityExprs.add(Eq(v.getConstDecl(0).ref, v.getConstDecl(1).ref))
+    }
     transOrder.createOnTop(MddVariableDescriptor.create(v.getConstDecl(0), 0))
   }
 }

--- a/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/mdd/node/expression/MddApproximation.java
+++ b/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/mdd/node/expression/MddApproximation.java
@@ -1,0 +1,70 @@
+/*
+ *  Copyright 2026 Budapest University of Technology and Economics
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package hu.bme.mit.theta.analysis.algorithm.mdd.node.expression;
+
+import com.google.common.base.Preconditions;
+
+/** What to do with a node that exceeds the edge limit. */
+public final class MddApproximation {
+
+    public static final int DEFAULT_EDGE_LIMIT = 1000;
+
+    public enum Strategy {
+        NONE,
+        UNDER,
+    }
+
+    private final Strategy strategy;
+    private final int edgeLimit;
+
+    private boolean underApproximated;
+
+    private MddApproximation(final Strategy strategy, final int edgeLimit) {
+        this.strategy = Preconditions.checkNotNull(strategy);
+        Preconditions.checkArgument(
+                edgeLimit > 0, "Edge limit must be positive, got %s", edgeLimit);
+        this.edgeLimit = edgeLimit;
+    }
+
+    public static MddApproximation exact() {
+        return new MddApproximation(Strategy.NONE, DEFAULT_EDGE_LIMIT);
+    }
+
+    public static MddApproximation of(final Strategy strategy, final int edgeLimit) {
+        return new MddApproximation(strategy, edgeLimit);
+    }
+
+    public Strategy getStrategy() {
+        return strategy;
+    }
+
+    public int getEdgeLimit() {
+        return edgeLimit;
+    }
+
+    void reportUnderApproximated() {
+        underApproximated = true;
+    }
+
+    public boolean isUnderApproximated() {
+        return underApproximated;
+    }
+
+    @Override
+    public String toString() {
+        return strategy + " with edge limit " + edgeLimit;
+    }
+}

--- a/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/mdd/node/expression/MddExpressionRepresentation.java
+++ b/subprojects/common/analysis/src/main/java/hu/bme/mit/theta/analysis/algorithm/mdd/node/expression/MddExpressionRepresentation.java
@@ -64,6 +64,9 @@ public class MddExpressionRepresentation implements RecursiveIntObjMapView<MddNo
     public static final MddGraph.Key<MddToExprStrategy> LOOK_AHEAD =
             new MddGraph.Key<>("lookAheadStrategy");
 
+    public static final MddGraph.Key<MddApproximation> APPROXIMATION =
+            new MddGraph.Key<>("approximation");
+
     public enum MddToExprStrategy {
         NONE {
             @Override
@@ -229,7 +232,7 @@ public class MddExpressionRepresentation implements RecursiveIntObjMapView<MddNo
                     && !explicitRepresentation.isComplete()
                     && explicitRepresentation.getCacheView().defaultValue() == null
                     && !mddVariable.isNullOrZero(childNode)) {
-                explicitRepresentation.cacheNode(key, childNode);
+                cacheExploredEdge(key, childNode);
                 completeIfBoolFullyCached();
             }
         }
@@ -246,6 +249,26 @@ public class MddExpressionRepresentation implements RecursiveIntObjMapView<MddNo
             repr = cont.getRepresentation();
         }
         return (MddExpressionRepresentation) repr;
+    }
+
+    private void cacheExploredEdge(final int key, final MddNode childNode) {
+        final MddApproximation approximation = approximation();
+        if (explicitRepresentation.getSize() < approximation.getEdgeLimit()) {
+            explicitRepresentation.cacheNode(key, childNode);
+            return;
+        }
+        switch (approximation.getStrategy()) {
+            case NONE -> throw new NotSolvableException();
+            case UNDER -> {
+                explicitRepresentation.setComplete();
+                approximation.reportUnderApproximated();
+            }
+        }
+    }
+
+    private MddApproximation approximation() {
+        final var configured = mddVariable.getMddGraph().getAttribute(APPROXIMATION);
+        return configured == null ? MddApproximation.exact() : configured;
     }
 
     /** A bool decl has exactly the keys 0 and 1, so deciding both makes the node complete. */
@@ -331,7 +354,7 @@ public class MddExpressionRepresentation implements RecursiveIntObjMapView<MddNo
             }
         }
         if (!mddVariable.isNullOrZero(childNode)) {
-            explicitRepresentation.cacheNode(key, childNode);
+            cacheExploredEdge(key, childNode);
         } else {
             // remember the absence, so the key is not queried again
             explicitRepresentation.cacheNegative(key);
@@ -438,9 +461,6 @@ public class MddExpressionRepresentation implements RecursiveIntObjMapView<MddNo
         void cacheNode(int key, MddNode node) {
             Preconditions.checkState(!complete);
             Preconditions.checkState(defaultValue == null);
-            if (this.cache.size() > 1000) {
-                throw new NotSolvableException();
-            }
             this.cache.put(key, node);
             this.edgeOrdering.add(key);
         }
@@ -677,10 +697,20 @@ public class MddExpressionRepresentation implements RecursiveIntObjMapView<MddNo
                         extendedModel.put(decl, literal);
                         modelToCache = extendedModel;
                     }
+                    cacheModel(modelToCache);
+                    final int key = LitExprConverter.toInt(literal);
+                    if (currentRepresentation.explicitRepresentation.isComplete()
+                            && !currentRepresentation
+                                    .explicitRepresentation
+                                    .getCacheView()
+                                    .containsKey(key)) {
+                        // the edge limit closed the level instead of taking this edge
+                        stopEnumeration();
+                        return QueryResult.failed();
+                    }
                     // Incrementally add negation for the newly found edge
                     solver.add(Neq(currentRepresentation.decl.getRef(), literal));
-                    cacheModel(modelToCache);
-                    return QueryResult.singleEdge(LitExprConverter.toInt(literal));
+                    return QueryResult.singleEdge(key);
                 } else {
                     stopEnumeration();
                     if (constraintApplied && !Objects.equals(constraint, True())) {

--- a/subprojects/common/analysis/src/test/java/hu/bme/mit/theta/analysis/algorithm/mdd/node/expression/MddApproximationTest.kt
+++ b/subprojects/common/analysis/src/test/java/hu/bme/mit/theta/analysis/algorithm/mdd/node/expression/MddApproximationTest.kt
@@ -1,0 +1,127 @@
+/*
+ *  Copyright 2026 Budapest University of Technology and Economics
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package hu.bme.mit.theta.analysis.algorithm.mdd.node.expression
+
+import hu.bme.mit.theta.analysis.algorithm.bounded.MonolithicExpr
+import hu.bme.mit.theta.analysis.algorithm.mdd.MddChecker
+import hu.bme.mit.theta.analysis.algorithm.mdd.fixedpoint.IterationStrategy
+import hu.bme.mit.theta.common.exception.NotSolvableException
+import hu.bme.mit.theta.common.logging.NullLogger
+import hu.bme.mit.theta.core.decl.Decls
+import hu.bme.mit.theta.core.type.Expr
+import hu.bme.mit.theta.core.type.abstracttype.AbstractExprs.Add
+import hu.bme.mit.theta.core.type.abstracttype.AbstractExprs.Eq
+import hu.bme.mit.theta.core.type.abstracttype.AbstractExprs.Leq
+import hu.bme.mit.theta.core.type.anytype.Exprs.Prime
+import hu.bme.mit.theta.core.type.booltype.BoolExprs.And
+import hu.bme.mit.theta.core.type.booltype.BoolExprs.Not
+import hu.bme.mit.theta.core.type.booltype.BoolType
+import hu.bme.mit.theta.core.type.inttype.IntExprs.Int
+import hu.bme.mit.theta.core.type.inttype.IntType
+import hu.bme.mit.theta.solver.SolverPool
+import hu.bme.mit.theta.solver.z3legacy.Z3LegacySolverFactory
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+
+/** `x` walks 0..[BOUND] so its level exceeds any limit below BOUND + 1; `y` never leaves 0. */
+class MddApproximationTest {
+
+  private val x = Decls.Var("x", IntType.getInstance())
+  private val y = Decls.Var("y", IntType.getInstance())
+
+  private companion object {
+    const val BOUND = 20
+    const val LIMIT = 4
+    const val GENEROUS_LIMIT = 10_000
+  }
+
+  private val init = And(Eq(x.ref, Int(0)), Eq(y.ref, Int(0)))
+  private val trans =
+    And(
+      Eq(Prime(x.ref), Add(x.ref, Int(1))),
+      Leq(Prime(x.ref), Int(BOUND)),
+      Eq(Prime(y.ref), y.ref),
+    )
+
+  private val holdsAboutY: Expr<BoolType> = Not(Eq(y.ref, Int(1)))
+
+  private val holdsAboutX: Expr<BoolType> = Not(Eq(x.ref, Int(BOUND + 100)))
+
+  private val violated: Expr<BoolType> = Not(Eq(x.ref, Int(5)))
+
+  private enum class Outcome {
+    SAFE,
+    UNSAFE,
+    UNKNOWN,
+  }
+
+  private fun check(prop: Expr<BoolType>, approximation: MddApproximation): Outcome {
+    SolverPool(Z3LegacySolverFactory.getInstance()).use { solverPool ->
+      val result =
+        MddChecker(
+            MonolithicExpr(init, trans, prop),
+            solverPool,
+            NullLogger.getInstance(),
+            IterationStrategy.GSAT,
+            approximation = approximation,
+          )
+          .check(null)
+      return when {
+        result.isSafe -> Outcome.SAFE
+        result.isUnsafe -> Outcome.UNSAFE
+        else -> Outcome.UNKNOWN
+      }
+    }
+  }
+
+  @Test
+  fun `without a strategy the limit still gives up`() {
+    assertThrows(NotSolvableException::class.java) {
+      check(violated, MddApproximation.of(MddApproximation.Strategy.NONE, LIMIT))
+    }
+  }
+
+  @ParameterizedTest
+  @EnumSource(MddApproximation.Strategy::class)
+  fun `a limit the model never reaches leaves the run exact`(strategy: MddApproximation.Strategy) {
+    val approximation = MddApproximation.of(strategy, GENEROUS_LIMIT)
+    assertEquals(Outcome.SAFE, check(holdsAboutY, approximation))
+    assertEquals(Outcome.SAFE, check(holdsAboutX, approximation))
+    assertEquals(Outcome.UNSAFE, check(violated, approximation))
+    assertTrue(!approximation.isUnderApproximated)
+  }
+
+  @Test
+  fun `truncating a level gives up the safety proof rather than a wrong answer`() {
+    val approximation = MddApproximation.of(MddApproximation.Strategy.UNDER, LIMIT)
+    assertEquals(Outcome.UNKNOWN, check(holdsAboutY, approximation))
+    assertTrue(approximation.isUnderApproximated)
+  }
+
+  @Test
+  fun `truncating a level never proves a property that is violated`() {
+    assertNotEquals(
+      Outcome.SAFE,
+      check(violated, MddApproximation.of(MddApproximation.Strategy.UNDER, LIMIT)),
+      "UNDER proved a property that is violated",
+    )
+  }
+}

--- a/subprojects/xcfa/xcfa-cli/src/main/java/hu/bme/mit/theta/xcfa/cli/checkers/ConfigToMddCegarChecker.kt
+++ b/subprojects/xcfa/xcfa-cli/src/main/java/hu/bme/mit/theta/xcfa/cli/checkers/ConfigToMddCegarChecker.kt
@@ -23,6 +23,8 @@ import hu.bme.mit.theta.analysis.algorithm.bounded.pipeline.passes.L2SMEPass
 import hu.bme.mit.theta.analysis.algorithm.mdd.cegar.MddCegarChecker
 import hu.bme.mit.theta.analysis.algorithm.mdd.result.MddProof
 import hu.bme.mit.theta.analysis.expl.ExplState
+import hu.bme.mit.theta.analysis.expr.refinement.createBwBinItpCheckerFactory
+import hu.bme.mit.theta.analysis.expr.refinement.createFwBinItpCheckerFactory
 import hu.bme.mit.theta.analysis.expr.refinement.createSeqItpCheckerFactory
 import hu.bme.mit.theta.analysis.ptr.PtrState
 import hu.bme.mit.theta.analysis.unit.UnitPrec
@@ -36,6 +38,7 @@ import hu.bme.mit.theta.xcfa.analysis.XcfaState
 import hu.bme.mit.theta.xcfa.analysis.monolithic.XcfaPipelineChecker
 import hu.bme.mit.theta.xcfa.analysis.proof.LocationInvariants
 import hu.bme.mit.theta.xcfa.cli.params.MddCegarConfig
+import hu.bme.mit.theta.xcfa.cli.params.MddCegarRefinement
 import hu.bme.mit.theta.xcfa.cli.params.XcfaConfig
 import hu.bme.mit.theta.xcfa.cli.utils.getSolver
 import hu.bme.mit.theta.xcfa.model.XCFA
@@ -52,18 +55,32 @@ fun getMddCegarChecker(
 
   val solverPool = SolverPool(solverFactory)
 
+  val refinementSolverFactory: SolverFactory =
+    if (
+      mddCegarConfig.refinementSolver.isEmpty() ||
+        mddCegarConfig.refinementSolver == mddCegarConfig.solver
+    )
+      solverFactory
+    else getSolver(mddCegarConfig.refinementSolver, mddCegarConfig.validateSolver)
+  val traceCheckerFactory =
+    when (mddCegarConfig.refinement) {
+      MddCegarRefinement.SEQ_ITP -> createSeqItpCheckerFactory(refinementSolverFactory)
+      MddCegarRefinement.FW_BIN_ITP -> createFwBinItpCheckerFactory(refinementSolverFactory)
+      MddCegarRefinement.BW_BIN_ITP -> createBwBinItpCheckerFactory(refinementSolverFactory)
+    }
+
   val baseChecker = { monolithicExpr: MonolithicExpr ->
     MddCegarChecker(
       monolithicExpr,
       solverPool,
       logger,
-      createSeqItpCheckerFactory(solverFactory),
+      traceCheckerFactory,
       iterationStrategy = mddCegarConfig.iterationStrategy,
-      useReachConstraint = mddCegarConfig.reachConstraint,
       useOnTheFlyReachability = mddCegarConfig.onTheFlyReachability,
       traceTimeout = mddCegarConfig.traceTimeout,
       lookAheadStrategy = mddCegarConfig.lookAheadStrategy,
       proofStrategy = mddCegarConfig.proofStrategy,
+      literalPlacement = mddCegarConfig.literalPlacement,
       traceSearch = mddCegarConfig.traceSearch,
     )
   }

--- a/subprojects/xcfa/xcfa-cli/src/main/java/hu/bme/mit/theta/xcfa/cli/checkers/ConfigToMddChecker.kt
+++ b/subprojects/xcfa/xcfa-cli/src/main/java/hu/bme/mit/theta/xcfa/cli/checkers/ConfigToMddChecker.kt
@@ -23,6 +23,7 @@ import hu.bme.mit.theta.analysis.algorithm.bounded.pipeline.passes.L2SMEPass
 import hu.bme.mit.theta.analysis.algorithm.bounded.pipeline.passes.PredicateAbstractionMEPass
 import hu.bme.mit.theta.analysis.algorithm.bounded.pipeline.passes.ReverseMEPass
 import hu.bme.mit.theta.analysis.algorithm.mdd.MddChecker
+import hu.bme.mit.theta.analysis.algorithm.mdd.node.expression.MddApproximation
 import hu.bme.mit.theta.analysis.algorithm.mdd.result.MddProof
 import hu.bme.mit.theta.analysis.expl.ExplState
 import hu.bme.mit.theta.analysis.expr.refinement.createFwBinItpCheckerFactory
@@ -65,6 +66,7 @@ fun getMddChecker(
       traceTimeout = mddConfig.traceTimeout,
       solverMeasurements = mddConfig.solverMeasurements,
       traceSearch = mddConfig.traceSearch,
+      approximation = MddApproximation.of(mddConfig.edgeCapStrategy, mddConfig.edgeLimit),
     )
   }
   val passes = mutableListOf<MonolithicExprPass<MddProof>>()

--- a/subprojects/xcfa/xcfa-cli/src/main/java/hu/bme/mit/theta/xcfa/cli/params/XcfaConfig.kt
+++ b/subprojects/xcfa/xcfa-cli/src/main/java/hu/bme/mit/theta/xcfa/cli/params/XcfaConfig.kt
@@ -20,6 +20,7 @@ import hu.bme.mit.theta.analysis.algorithm.loopchecker.abstraction.LoopCheckerSe
 import hu.bme.mit.theta.analysis.algorithm.loopchecker.refinement.ASGTraceCheckerStrategy
 import hu.bme.mit.theta.analysis.algorithm.mdd.cegar.LiteralPlacement
 import hu.bme.mit.theta.analysis.algorithm.mdd.fixedpoint.IterationStrategy
+import hu.bme.mit.theta.analysis.algorithm.mdd.node.expression.MddApproximation
 import hu.bme.mit.theta.analysis.algorithm.mdd.node.expression.MddExpressionRepresentation
 import hu.bme.mit.theta.analysis.algorithm.mdd.trace.TraceSearch
 import hu.bme.mit.theta.analysis.expr.refinement.PruneStrategy
@@ -676,6 +677,18 @@ data class MddConfig(
     description = "Perform a structural rerun to estimate solver time overhead",
   )
   var solverMeasurements: Boolean = false,
+  @Parameter(
+    names = ["--edge-cap-strategy"],
+    description =
+      "What to do with a decision diagram node that exceeds --edge-limit: NONE gives up (verification stuck), UNDER keeps the edges found so far and keeps only an unsafe verdict",
+  )
+  var edgeCapStrategy: MddApproximation.Strategy = MddApproximation.Strategy.NONE,
+  @Parameter(
+    names = ["--edge-limit"],
+    description =
+      "Explicit edges allowed on a single decision diagram node before --edge-cap-strategy applies",
+  )
+  var edgeLimit: Int = MddApproximation.DEFAULT_EDGE_LIMIT,
   @Parameter(names = ["--reversed"], description = "Create a reversed monolithic expression")
   var reversed: Boolean = false,
   @Parameter(names = ["--cegar"], description = "Wrap the check in a predicate-based CEGAR loop")

--- a/subprojects/xcfa/xcfa-cli/src/main/java/hu/bme/mit/theta/xcfa/cli/params/XcfaConfig.kt
+++ b/subprojects/xcfa/xcfa-cli/src/main/java/hu/bme/mit/theta/xcfa/cli/params/XcfaConfig.kt
@@ -18,6 +18,7 @@ package hu.bme.mit.theta.xcfa.cli.params
 import com.beust.jcommander.Parameter
 import hu.bme.mit.theta.analysis.algorithm.loopchecker.abstraction.LoopCheckerSearchStrategy
 import hu.bme.mit.theta.analysis.algorithm.loopchecker.refinement.ASGTraceCheckerStrategy
+import hu.bme.mit.theta.analysis.algorithm.mdd.cegar.LiteralPlacement
 import hu.bme.mit.theta.analysis.algorithm.mdd.fixedpoint.IterationStrategy
 import hu.bme.mit.theta.analysis.algorithm.mdd.node.expression.MddExpressionRepresentation
 import hu.bme.mit.theta.analysis.algorithm.mdd.trace.TraceSearch
@@ -683,9 +684,22 @@ data class MddConfig(
   var initPrec: InitPrec = InitPrec.EMPTY,
 ) : SpecBackendConfig
 
+enum class MddCegarRefinement {
+  SEQ_ITP,
+  FW_BIN_ITP,
+  BW_BIN_ITP,
+}
+
 data class MddCegarConfig(
   @Parameter(names = ["--solver", "--mdd-solver"], description = "MDD solver name")
   var solver: String = "Z3",
+  @Parameter(
+    names = ["--refinement-solver"],
+    description = "Solver for the trace check / interpolation (defaults to --solver)",
+  )
+  var refinementSolver: String = "",
+  @Parameter(names = ["--refinement"], description = "Trace checker used for refinement")
+  var refinement: MddCegarRefinement = MddCegarRefinement.SEQ_ITP,
   @Parameter(
     names = ["--validate-solver", "--validate-mdd-solver"],
     description =
@@ -712,22 +726,22 @@ data class MddCegarConfig(
   @Parameter(names = ["--trace-timeout"], description = "Timeout for trace generation")
   var traceTimeout: Long = 10,
   @Parameter(
-    names = ["--reach-constraint"],
-    description = "Constrain each iteration's saturation to the previous iteration's reach set",
-    arity = 1,
-  )
-  var reachConstraint: Boolean = false,
-  @Parameter(
     names = ["--on-the-fly-reachability"],
     description = "Terminate saturation as soon as a violating state is reached",
   )
   var onTheFlyReachability: Boolean = false,
   @Parameter(
+    names = ["--literal-placement"],
+    description =
+      "Where the literal levels go in the MDD orders: FORCE (the FORCE ordering of ctrl vars and literals, rebuilt every iteration) or TOP (each new literal on top of the existing levels)",
+  )
+  var literalPlacement: LiteralPlacement = LiteralPlacement.FORCE,
+  @Parameter(
     names = ["--trace-search"],
     description =
-      "Counterexample search over the state space: DFS (backward, one predecessor per step), BFS (forward layers, shortest counterexample) or BFS_BACKWARD (backward layers from all violating states)",
+      "Search for the abstract counterexample: BFS (forward layers then one backward step per layer: shortest counterexample), BFS_BACKWARD (backward layers from all violating states) or DFS (backward, one predecessor per step, order-dependent length)",
   )
-  var traceSearch: TraceSearch = TraceSearch.DFS,
+  var traceSearch: TraceSearch = TraceSearch.BFS,
 ) : SpecBackendConfig
 
 data class Ic3Config(


### PR DESCRIPTION
## MDD CEGAR:

- The abstract relation is split per transition group. Concrete transitions with the same connected literals (predicates sharing a variable with the transition, transitively) form one group.
- Refinement uses the transition that fired. Each counterexample step is checked with the concrete transition of its step, not the whole relation.
- `--literal-placement FORCE` (the default) runs the FORCE ordering over the abstract model every iteration. `TOP` keeps adding literal levels on top, as before.
- `--refinement SEQ_ITP|FW_BIN_ITP|BW_BIN_ITP` selects the trace checker and `--refinement-solver` the solver for the trace check and interpolation.

## Saturation: `--edge-cap-strategy UNDER`

`--edge-cap-strategy` replaces the hard-wired 1000-edge `NotSolvableException`. `NONE` keeps the old behaviour and stays the default. `UNDER`: each node can have at most `edge-limit` edges; a run that hit the limit and found no violation is reported as unknown instead of safe. `--edge-limit` sets the threshold.