### PR TITLE
strcpy type fix

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -86,7 +86,7 @@ buildscript {
 
 allprojects {
     group = "hu.bme.mit.theta"
-    version = "8.0.0"
+    version = "8.0.1"
 
     apply(from = rootDir.resolve("gradle/shared-with-buildSrc/mirrors.gradle.kts"))
 }

--- a/subprojects/xcfa/xcfa/src/main/java/hu/bme/mit/theta/xcfa/passes/CLibraryFunctionsPass.kt
+++ b/subprojects/xcfa/xcfa/src/main/java/hu/bme/mit/theta/xcfa/passes/CLibraryFunctionsPass.kt
@@ -93,6 +93,8 @@ class CLibraryFunctionsPass(val parseContext: ParseContext) : ProcedurePass {
      * such variables, as their integer encoding (e.g. `m == 0`) is not a valid C expression.
      */
     const val SYNC_VAR_METADATA_KEY = "synchronizationObject"
+
+    private var uniqueCounter = 0
   }
 
   /** Tags [handle] as a synchronization object (no-op when no [parseContext] is available). */
@@ -140,7 +142,8 @@ class CLibraryFunctionsPass(val parseContext: ParseContext) : ProcedurePass {
                 val copyTarget = invokeLabel.params[1]
 
                 val type = copySource.type
-                val indexVar = Decls.Var("__strcpy_index_var", type)
+                val indexVar = Decls.Var("__theta_strcpy_index_var_${uniqueCounter++}", type)
+                builder.addVar(indexVar)
                 val initLabel = AssignStmtLabel(indexVar, type.integerOf(0))
                 val loc = XcfaLocation("${it.source.name}_strcpy", metadata = it.source.metadata)
                 val initEdge = XcfaEdge(it.source, loc, SequenceLabel(listOf(initLabel)), metadata)

--- a/subprojects/xcfa/xcfa/src/main/java/hu/bme/mit/theta/xcfa/passes/CLibraryFunctionsPass.kt
+++ b/subprojects/xcfa/xcfa/src/main/java/hu/bme/mit/theta/xcfa/passes/CLibraryFunctionsPass.kt
@@ -22,7 +22,6 @@ import hu.bme.mit.theta.core.stmt.AssumeStmt
 import hu.bme.mit.theta.core.stmt.MemoryAssignStmt
 import hu.bme.mit.theta.core.type.Expr
 import hu.bme.mit.theta.core.type.abstracttype.AbstractExprs.Add
-import hu.bme.mit.theta.core.type.abstracttype.AddExpr
 import hu.bme.mit.theta.core.type.abstracttype.EqExpr
 import hu.bme.mit.theta.core.type.abstracttype.NeqExpr
 import hu.bme.mit.theta.core.type.anytype.Dereference
@@ -38,7 +37,6 @@ import hu.bme.mit.theta.frontend.transformation.model.types.complex.CComplexType
 import hu.bme.mit.theta.xcfa.model.*
 import hu.bme.mit.theta.xcfa.utils.AssignStmtLabel
 import hu.bme.mit.theta.xcfa.utils.collectVarsWithAccessType
-import hu.bme.mit.theta.xcfa.utils.defaultValue
 import hu.bme.mit.theta.xcfa.utils.getFlatLabels
 import hu.bme.mit.theta.xcfa.utils.integerOf
 import hu.bme.mit.theta.xcfa.utils.isWritten
@@ -151,7 +149,10 @@ class CLibraryFunctionsPass(val parseContext: ParseContext) : ProcedurePass {
                 val sourceDeref = Dereference.of(copySource, indexVar.ref, copySource.type)
                 val targetDeref = Dereference.of(copyTarget, indexVar.ref, copyTarget.type)
 
-                val continueAssume = StmtLabel(AssumeStmt.of(NeqExpr.create2(sourceDeref, copySource.type.integerOf(0))))
+                val continueAssume =
+                  StmtLabel(
+                    AssumeStmt.of(NeqExpr.create2(sourceDeref, copySource.type.integerOf(0)))
+                  )
                 val copyCurrent = StmtLabel(MemoryAssignStmt.of(targetDeref, sourceDeref))
                 val increment =
                   AssignStmtLabel(indexVar.ref, Add(listOf(indexVar.ref, type.integerOf(1))))
@@ -159,7 +160,10 @@ class CLibraryFunctionsPass(val parseContext: ParseContext) : ProcedurePass {
                 val copyEdge = XcfaEdge(loc, loc, copyLabel, metadata)
                 builder.addEdge(copyEdge)
 
-                val exitAssume = StmtLabel(AssumeStmt.of(EqExpr.create2(sourceDeref, copySource.type.integerOf(0))))
+                val exitAssume =
+                  StmtLabel(
+                    AssumeStmt.of(EqExpr.create2(sourceDeref, copySource.type.integerOf(0)))
+                  )
                 val exitLabel = SequenceLabel(listOf(exitAssume))
                 val exitEdge = XcfaEdge(loc, target, exitLabel, metadata)
                 builder.addEdge(exitEdge)

--- a/subprojects/xcfa/xcfa/src/main/java/hu/bme/mit/theta/xcfa/passes/CLibraryFunctionsPass.kt
+++ b/subprojects/xcfa/xcfa/src/main/java/hu/bme/mit/theta/xcfa/passes/CLibraryFunctionsPass.kt
@@ -21,6 +21,7 @@ import hu.bme.mit.theta.core.decl.VarDecl
 import hu.bme.mit.theta.core.stmt.AssumeStmt
 import hu.bme.mit.theta.core.stmt.MemoryAssignStmt
 import hu.bme.mit.theta.core.type.Expr
+import hu.bme.mit.theta.core.type.abstracttype.AbstractExprs.Add
 import hu.bme.mit.theta.core.type.abstracttype.AddExpr
 import hu.bme.mit.theta.core.type.abstracttype.EqExpr
 import hu.bme.mit.theta.core.type.abstracttype.NeqExpr
@@ -37,7 +38,9 @@ import hu.bme.mit.theta.frontend.transformation.model.types.complex.CComplexType
 import hu.bme.mit.theta.xcfa.model.*
 import hu.bme.mit.theta.xcfa.utils.AssignStmtLabel
 import hu.bme.mit.theta.xcfa.utils.collectVarsWithAccessType
+import hu.bme.mit.theta.xcfa.utils.defaultValue
 import hu.bme.mit.theta.xcfa.utils.getFlatLabels
+import hu.bme.mit.theta.xcfa.utils.integerOf
 import hu.bme.mit.theta.xcfa.utils.isWritten
 import java.math.BigInteger
 
@@ -138,24 +141,25 @@ class CLibraryFunctionsPass(val parseContext: ParseContext) : ProcedurePass {
                 val copySource = invokeLabel.params[2]
                 val copyTarget = invokeLabel.params[1]
 
-                val indexVar = Decls.Var("__strcpy_index_var", Int())
-                val initLabel = AssignStmtLabel(indexVar, Int(0))
+                val type = copySource.type
+                val indexVar = Decls.Var("__strcpy_index_var", type)
+                val initLabel = AssignStmtLabel(indexVar, type.integerOf(0))
                 val loc = XcfaLocation("${it.source.name}_strcpy", metadata = it.source.metadata)
                 val initEdge = XcfaEdge(it.source, loc, SequenceLabel(listOf(initLabel)), metadata)
                 builder.addEdge(initEdge)
 
-                val sourceDeref = Dereference.of(copySource, indexVar.ref, Int())
-                val targetDeref = Dereference.of(copyTarget, indexVar.ref, Int())
+                val sourceDeref = Dereference.of(copySource, indexVar.ref, copySource.type)
+                val targetDeref = Dereference.of(copyTarget, indexVar.ref, copyTarget.type)
 
-                val continueAssume = StmtLabel(AssumeStmt.of(NeqExpr.create2(sourceDeref, Int(0))))
+                val continueAssume = StmtLabel(AssumeStmt.of(NeqExpr.create2(sourceDeref, copySource.type.integerOf(0))))
                 val copyCurrent = StmtLabel(MemoryAssignStmt.of(targetDeref, sourceDeref))
                 val increment =
-                  AssignStmtLabel(indexVar.ref, AddExpr.create2(listOf(indexVar.ref, Int(1))))
+                  AssignStmtLabel(indexVar.ref, Add(listOf(indexVar.ref, type.integerOf(1))))
                 val copyLabel = SequenceLabel(listOf(continueAssume, copyCurrent, increment))
                 val copyEdge = XcfaEdge(loc, loc, copyLabel, metadata)
                 builder.addEdge(copyEdge)
 
-                val exitAssume = StmtLabel(AssumeStmt.of(EqExpr.create2(sourceDeref, Int(0))))
+                val exitAssume = StmtLabel(AssumeStmt.of(EqExpr.create2(sourceDeref, copySource.type.integerOf(0))))
                 val exitLabel = SequenceLabel(listOf(exitAssume))
                 val exitEdge = XcfaEdge(loc, target, exitLabel, metadata)
                 builder.addEdge(exitEdge)

--- a/subprojects/xcfa/xcfa/src/main/java/hu/bme/mit/theta/xcfa/utils/TypeDefaults.kt
+++ b/subprojects/xcfa/xcfa/src/main/java/hu/bme/mit/theta/xcfa/utils/TypeDefaults.kt
@@ -26,6 +26,7 @@ import hu.bme.mit.theta.core.type.booltype.TrueExpr
 import hu.bme.mit.theta.core.type.bvtype.BvType
 import hu.bme.mit.theta.core.type.fptype.FpType
 import hu.bme.mit.theta.core.type.inttype.IntExprs.Int
+import hu.bme.mit.theta.core.type.inttype.IntLitExpr
 import hu.bme.mit.theta.core.type.inttype.IntType
 import hu.bme.mit.theta.core.type.rattype.RatExprs.Rat
 import hu.bme.mit.theta.core.type.rattype.RatType
@@ -65,6 +66,13 @@ val Type.defaultValue: LitExpr<out Type>
           ArrayType.of(indexType, elemType),
         )
       else -> error("No default value for type $this")
+    }
+
+fun Type.integerOf(value: Int): LitExpr<out Type> =
+    when (this) {
+      is IntType -> Int(value)
+      is BvType -> BvUtils.bigIntegerToNeutralBvLitExpr(BigInteger.valueOf(value.toLong()), size)
+      else -> error("Cannot create an integer value of type $this")
     }
 
 /**

--- a/subprojects/xcfa/xcfa/src/main/java/hu/bme/mit/theta/xcfa/utils/TypeDefaults.kt
+++ b/subprojects/xcfa/xcfa/src/main/java/hu/bme/mit/theta/xcfa/utils/TypeDefaults.kt
@@ -26,7 +26,6 @@ import hu.bme.mit.theta.core.type.booltype.TrueExpr
 import hu.bme.mit.theta.core.type.bvtype.BvType
 import hu.bme.mit.theta.core.type.fptype.FpType
 import hu.bme.mit.theta.core.type.inttype.IntExprs.Int
-import hu.bme.mit.theta.core.type.inttype.IntLitExpr
 import hu.bme.mit.theta.core.type.inttype.IntType
 import hu.bme.mit.theta.core.type.rattype.RatExprs.Rat
 import hu.bme.mit.theta.core.type.rattype.RatType
@@ -69,11 +68,11 @@ val Type.defaultValue: LitExpr<out Type>
     }
 
 fun Type.integerOf(value: Int): LitExpr<out Type> =
-    when (this) {
-      is IntType -> Int(value)
-      is BvType -> BvUtils.bigIntegerToNeutralBvLitExpr(BigInteger.valueOf(value.toLong()), size)
-      else -> error("Cannot create an integer value of type $this")
-    }
+  when (this) {
+    is IntType -> Int(value)
+    is BvType -> BvUtils.bigIntegerToNeutralBvLitExpr(BigInteger.valueOf(value.toLong()), size)
+    else -> error("Cannot create an integer value of type $this")
+  }
 
 /**
  * States that a havoced value is one its C type can actually hold.


### PR DESCRIPTION
Closes #556.
Probably the actual culprit was ReferenceElimination trying to assign an arbitrary type to an offset (the strcpy index counter has its own right to have a different Int type). Nevertheless, it was easier to patch CLibraryFunctionsPass to use the type of the copied dereference which actually matches the type forced by reference elimination.