### PR TITLE
Drop unread string literal initialization, and copy strcpy's terminator

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -86,7 +86,7 @@ buildscript {
 
 allprojects {
     group = "hu.bme.mit.theta"
-    version = "8.0.1"
+    version = "8.0.2"
 
     apply(from = rootDir.resolve("gradle/shared-with-buildSrc/mirrors.gradle.kts"))
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -86,7 +86,7 @@ buildscript {
 
 allprojects {
     group = "hu.bme.mit.theta"
-    version = "8.0.0"
+    version = "8.0.1"
 
     apply(from = rootDir.resolve("gradle/shared-with-buildSrc/mirrors.gradle.kts"))
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -86,7 +86,7 @@ buildscript {
 
 allprojects {
     group = "hu.bme.mit.theta"
-    version = "8.0.2"
+    version = "8.0.5"
 
     apply(from = rootDir.resolve("gradle/shared-with-buildSrc/mirrors.gradle.kts"))
 }

--- a/subprojects/xcfa/xcfa-cli/canaries/fixtures/fixtures.tsv
+++ b/subprojects/xcfa/xcfa-cli/canaries/fixtures/fixtures.tsv
@@ -74,3 +74,5 @@ nondet_memory_symbolic_size.c	efficient	LP64	UNSAFE	__VERIFIER_nondet_memory wit
 nondet_memory_stays_in_region.c	efficient	LP64	SAFE	the nondet fill writes only the region it was given, not the whole object
 stub_write_race.c	efficient	LP64	UNSAFE:no-data-race	a library stub writing through a pointer argument stays visible to the data-race instrumentation
 stub_arg_read_race.c	efficient	LP64	UNSAFE:no-data-race	stubbing a call keeps the reads of its arguments (a race on one of them is still reported)
+string_literal_read.c	efficient	ILP32	SAFE	a string literal whose characters are read keeps its initialization
+strcpy_terminator.c	efficient	ILP32	SAFE	strcpy copies the terminating null byte, not only the characters before it

--- a/subprojects/xcfa/xcfa-cli/canaries/fixtures/strcpy_terminator.c
+++ b/subprojects/xcfa/xcfa-cli/canaries/fixtures/strcpy_terminator.c
@@ -1,0 +1,10 @@
+// strcpy copies the terminating null byte, so the destination is a valid string afterwards.
+extern void abort(void);
+void reach_error() { abort(); }
+extern char *strcpy(char *, const char *);
+int main(void) {
+  char dst[4];
+  strcpy(dst, "AB");
+  if (dst[0] != 'A' || dst[1] != 'B' || dst[2] != 0) reach_error();
+  return 0;
+}

--- a/subprojects/xcfa/xcfa-cli/canaries/fixtures/string_literal_read.c
+++ b/subprojects/xcfa/xcfa-cli/canaries/fixtures/string_literal_read.c
@@ -1,0 +1,9 @@
+// A string literal whose characters are read keeps its initialization: dropping the
+// per-character init of a literal nothing reads must not touch one that is read.
+extern void abort(void);
+void reach_error() { abort(); }
+int main(void) {
+  const char *s = "AB";
+  if (s[0] != 'A' || s[1] != 'B' || s[2] != 0) reach_error();
+  return 0;
+}

--- a/subprojects/xcfa/xcfa/src/main/java/hu/bme/mit/theta/xcfa/passes/CLibraryFunctionsPass.kt
+++ b/subprojects/xcfa/xcfa/src/main/java/hu/bme/mit/theta/xcfa/passes/CLibraryFunctionsPass.kt
@@ -156,7 +156,11 @@ class CLibraryFunctionsPass(val parseContext: ParseContext) : ProcedurePass {
                 builder.addEdge(copyEdge)
 
                 val exitAssume = StmtLabel(AssumeStmt.of(EqExpr.create2(sourceDeref, Int(0))))
-                val exitLabel = SequenceLabel(listOf(exitAssume))
+                // strcpy copies the terminating null byte as well; leaving it out left the
+                // destination unterminated, so reading the byte past the copied characters gave
+                // whatever was there before.
+                val copyTerminator = StmtLabel(MemoryAssignStmt.of(targetDeref, sourceDeref))
+                val exitLabel = SequenceLabel(listOf(exitAssume, copyTerminator))
                 val exitEdge = XcfaEdge(loc, target, exitLabel, metadata)
                 builder.addEdge(exitEdge)
               }

--- a/subprojects/xcfa/xcfa/src/main/java/hu/bme/mit/theta/xcfa/passes/ProcedurePassManager.kt
+++ b/subprojects/xcfa/xcfa/src/main/java/hu/bme/mit/theta/xcfa/passes/ProcedurePassManager.kt
@@ -89,6 +89,8 @@ class CPasses(property: XcfaProperty, parseContext: ParseContext, uniqueWarningL
       ReferenceElimination(parseContext)
     ),
     listOf(
+      // after inlining, so a read through a callee's parameter is a read through the literal here
+      StringLiteralInitPass(),
       EmptyEdgeRemovalPass(),
       SimplifyExprsPass(parseContext, property),
       UnusedLocRemovalPass(),

--- a/subprojects/xcfa/xcfa/src/main/java/hu/bme/mit/theta/xcfa/passes/StringLiteralInitPass.kt
+++ b/subprojects/xcfa/xcfa/src/main/java/hu/bme/mit/theta/xcfa/passes/StringLiteralInitPass.kt
@@ -1,0 +1,147 @@
+/*
+ *  Copyright 2026 Budapest University of Technology and Economics
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package hu.bme.mit.theta.xcfa.passes
+
+import hu.bme.mit.theta.core.decl.VarDecl
+import hu.bme.mit.theta.core.stmt.AssignStmt
+import hu.bme.mit.theta.core.stmt.MemoryAssignStmt
+import hu.bme.mit.theta.core.type.anytype.RefExpr
+import hu.bme.mit.theta.core.utils.ExprUtils
+import hu.bme.mit.theta.xcfa.model.*
+import hu.bme.mit.theta.xcfa.utils.dereferencesWithAccessType
+import hu.bme.mit.theta.xcfa.utils.isRead
+
+/**
+ * Drops the character-by-character initialization of a string literal nothing ever reads.
+ *
+ * The frontend gives every string literal its own storage and fills it one cell per character, so a
+ * program that merely prints its diagnostics pays a location and a memory write per character of
+ * every message it can emit. That is most of the model in the string-heavy benchmarks, and none of
+ * it is reachable by the property: the pointer is compared against null and handed to a library
+ * stub, and no cell is ever read back.
+ *
+ * A literal keeps its initialization if any dereference *reads* one of its cells, or if the pointer
+ * is stored into memory -- from where it could be loaded again and dereferenced through a base this
+ * cannot recognize. Passing it to a call or assigning it to a variable is not enough on its own:
+ * those keep the pointer syntactically visible, so a later content read still names this variable.
+ *
+ * Runs after inlining, where a read through a callee's parameter has become a read through this
+ * variable.
+ */
+class StringLiteralInitPass : ProcedurePass {
+
+  private companion object {
+    /** The frontend names each string literal's storage `__theta_str<n>`. */
+    val STRING_LITERAL = Regex("""__theta_str\d+$""")
+  }
+
+  private var unread: Set<VarDecl<*>>? = null
+
+  override fun run(builder: XcfaProcedureBuilder): XcfaProcedureBuilder {
+    val dead = unread ?: unreadLiterals(builder.parent).also { unread = it }
+    if (dead.isEmpty()) return builder
+    builder.getEdges().toList().forEach { edge ->
+      val stripped = edge.label.withoutInitOf(dead)
+      if (stripped != edge.label) {
+        builder.removeEdge(edge)
+        builder.addEdge(edge.withLabel(stripped))
+      }
+    }
+    return builder
+  }
+
+  private fun unreadLiterals(xcfa: XcfaBuilder): Set<VarDecl<*>> {
+    val scan = Scan()
+    xcfa.getProcedures().forEach { procedure ->
+      procedure.getEdges().forEach { edge -> scan.visit(edge.label) }
+    }
+    return scan.droppable()
+  }
+
+  /**
+   * What the whole program does with each string literal's address.
+   *
+   * The address reaches a read through a pointer variable, not through the literal itself, so the
+   * flow has to be followed: `mayHold` says which literals a variable can hold, propagated over
+   * assignments to a fixpoint, and any variable used as a dereference base keeps everything it can
+   * hold.
+   */
+  private class Scan {
+    val initialized = mutableSetOf<VarDecl<*>>()
+    val readDirectly = mutableSetOf<VarDecl<*>>()
+    val storedToMemory = mutableSetOf<VarDecl<*>>()
+    val derefBases = mutableSetOf<VarDecl<*>>()
+    val assignments = mutableListOf<Pair<VarDecl<*>, List<VarDecl<*>>>>()
+
+    fun visit(label: XcfaLabel) {
+      when (label) {
+        is NondetLabel -> label.labels.forEach(::visit)
+        is SequenceLabel -> label.labels.forEach(::visit)
+        else -> {
+          label.dereferencesWithAccessType.forEach { (deref, access) ->
+            val vars = ExprUtils.getVars(deref.array)
+            derefBases.addAll(vars)
+            val root = (deref.array as? RefExpr<*>)?.decl as? VarDecl<*>
+            if (root != null && root.isStringLiteral() && vars == setOf(root)) {
+              if (access.isRead) readDirectly.add(root) else initialized.add(root)
+            } else {
+              readDirectly.addAll(vars.filter { it.isStringLiteral() })
+            }
+          }
+          val stmt = (label as? StmtLabel)?.stmt
+          if (stmt is MemoryAssignStmt<*, *, *>) {
+            storedToMemory.addAll(ExprUtils.getVars(stmt.expr).filter { it.isStringLiteral() })
+          }
+          if (stmt is AssignStmt<*>) {
+            assignments.add(stmt.varDecl to ExprUtils.getVars(stmt.expr).toList())
+          }
+        }
+      }
+    }
+
+    fun droppable(): Set<VarDecl<*>> {
+      val mayHold = mutableMapOf<VarDecl<*>, MutableSet<VarDecl<*>>>()
+      var changed = true
+      while (changed) {
+        changed = false
+        assignments.forEach { (target, sources) ->
+          val holds = mayHold.getOrPut(target) { mutableSetOf() }
+          val incoming =
+            sources.flatMap { if (it.isStringLiteral()) listOf(it) else mayHold[it].orEmpty() }
+          if (holds.addAll(incoming)) changed = true
+        }
+      }
+      val keep = readDirectly + storedToMemory + derefBases.flatMap { mayHold[it].orEmpty() }
+      return initialized - keep
+    }
+  }
+
+  private fun XcfaLabel.withoutInitOf(dead: Set<VarDecl<*>>): XcfaLabel =
+    when (this) {
+      is SequenceLabel -> SequenceLabel(labels.map { it.withoutInitOf(dead) }, metadata)
+      is StmtLabel -> {
+        val assign = stmt as? MemoryAssignStmt<*, *, *>
+        val base = (assign?.deref?.array as? RefExpr<*>)?.decl as? VarDecl<*>
+        if (base != null && base in dead) NopLabel else this
+      }
+
+      else -> this
+    }
+}
+
+private val STRING_LITERAL_NAME = Regex("""__theta_str\d+$""")
+
+private fun VarDecl<*>.isStringLiteral() = STRING_LITERAL_NAME.containsMatchIn(name)

--- a/subprojects/xcfa/xcfa/src/main/java/hu/bme/mit/theta/xcfa/passes/StringLiteralInitPass.kt
+++ b/subprojects/xcfa/xcfa/src/main/java/hu/bme/mit/theta/xcfa/passes/StringLiteralInitPass.kt
@@ -43,11 +43,6 @@ import hu.bme.mit.theta.xcfa.utils.isRead
  */
 class StringLiteralInitPass : ProcedurePass {
 
-  private companion object {
-    /** The frontend names each string literal's storage `__theta_str<n>`. */
-    val STRING_LITERAL = Regex("""__theta_str\d+$""")
-  }
-
   private var unread: Set<VarDecl<*>>? = null
 
   override fun run(builder: XcfaProcedureBuilder): XcfaProcedureBuilder {
@@ -142,6 +137,7 @@ class StringLiteralInitPass : ProcedurePass {
     }
 }
 
+/** The frontend names each string literal's storage `__theta_str<n>`. */
 private val STRING_LITERAL_NAME = Regex("""__theta_str\d+$""")
 
 private fun VarDecl<*>.isStringLiteral() = STRING_LITERAL_NAME.containsMatchIn(name)

--- a/subprojects/xcfa/xcfa/src/test/java/hu/bme/mit/theta/xcfa/passes/StringLiteralInitPassTest.kt
+++ b/subprojects/xcfa/xcfa/src/test/java/hu/bme/mit/theta/xcfa/passes/StringLiteralInitPassTest.kt
@@ -1,0 +1,114 @@
+/*
+ *  Copyright 2026 Budapest University of Technology and Economics
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package hu.bme.mit.theta.xcfa.passes
+
+import hu.bme.mit.theta.core.decl.VarDecl
+import hu.bme.mit.theta.core.stmt.MemoryAssignStmt
+import hu.bme.mit.theta.core.type.anytype.RefExpr
+import hu.bme.mit.theta.core.type.inttype.IntExprs.Int
+import hu.bme.mit.theta.xcfa.model.*
+import hu.bme.mit.theta.xcfa.utils.getFlatLabels
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * The pass drops a string literal's per-character initialization only when nothing can read it
+ * back. Every way the address can still reach a read has to hold it back, or the program loses
+ * writes it depends on.
+ */
+class StringLiteralInitPassTest {
+
+  private fun runPass(input: XcfaProcedureBuilderContext.() -> Unit): XcfaProcedureBuilder =
+    StringLiteralInitPass().runChecked(XcfaBuilder("").procedure("main", input).builder)
+
+  /** Writes still aimed at a literal's cells after the pass. */
+  private fun XcfaProcedureBuilder.literalInitWrites(): Int =
+    getEdges()
+      .flatMap { it.label.getFlatLabels() }
+      .count { label ->
+        val deref = ((label as? StmtLabel)?.stmt as? MemoryAssignStmt<*, *, *>)?.deref
+        val base = (deref?.array as? RefExpr<*>)?.decl as? VarDecl<*>
+        base?.name?.contains("__theta_str") == true
+      }
+
+  @Test
+  fun unreadLiteralInitializationIsDropped() {
+    val result = runPass {
+      "__theta_str0" type Int()
+      (init to "L1") {
+        "(deref __theta_str0 0 Int)" memassign "104"
+        "(deref __theta_str0 1 Int)" memassign "105"
+        "(deref __theta_str0 2 Int)" memassign "0"
+      }
+    }
+    assertEquals(0, result.literalInitWrites())
+  }
+
+  @Test
+  fun aReadCellKeepsTheInitialization() {
+    val result = runPass {
+      "__theta_str0" type Int()
+      "c" type Int()
+      (init to "L1") { "(deref __theta_str0 0 Int)" memassign "104" }
+      ("L1" to "L2") { "c" assign "(deref __theta_str0 0 Int)" }
+    }
+    assertEquals(1, result.literalInitWrites())
+  }
+
+  /**
+   * Reads go through a pointer variable, never the literal itself, and the pointer may have been
+   * copied more than once on the way -- so the address has to be followed to a fixpoint.
+   */
+  @Test
+  fun aLiteralReachedThroughCopiedPointersKeepsTheInitialization() {
+    val result = runPass {
+      "__theta_str0" type Int()
+      "s" type Int()
+      "t" type Int()
+      "c" type Int()
+      (init to "L1") { "(deref __theta_str0 0 Int)" memassign "104" }
+      ("L1" to "L2") { "s" assign "__theta_str0" }
+      ("L2" to "L3") { "t" assign "s" }
+      ("L3" to "L4") { "c" assign "(deref t 0 Int)" }
+    }
+    assertEquals(1, result.literalInitWrites())
+  }
+
+  /** Once the address is in memory it can be loaded back through a base the pass cannot name. */
+  @Test
+  fun aLiteralStoredIntoMemoryKeepsTheInitialization() {
+    val result = runPass {
+      "__theta_str0" type Int()
+      "p" type Int()
+      (init to "L1") { "(deref __theta_str0 0 Int)" memassign "104" }
+      ("L1" to "L2") { "(deref p 0 Int)" memassign "__theta_str0" }
+    }
+    assertEquals(1, result.literalInitWrites())
+  }
+
+  /** A pointer copied from a literal but only ever compared is still not a read of its cells. */
+  @Test
+  fun aCopiedPointerThatIsNeverDereferencedIsStillDropped() {
+    val result = runPass {
+      "__theta_str0" type Int()
+      "s" type Int()
+      (init to "L1") { "(deref __theta_str0 0 Int)" memassign "104" }
+      ("L1" to "L2") { "s" assign "__theta_str0" }
+      ("L2" to "L3") { assume("(/= s 0)") }
+    }
+    assertEquals(0, result.literalInitWrites())
+  }
+}


### PR DESCRIPTION
Two frontend/pass fixes found while bisecting the run 110 regression (#564).

## 1. String literal initialization nothing reads

`4724647fe7` gave every string literal its storage and filled it one cell per character. In the string-heavy benchmarks that is most of the model and none of it is reachable by the property: the pointer is compared against null and handed to a library stub, and no cell is ever read back.

`StringLiteralInitPass` drops that initialization for a literal whose contents nothing reads. A literal is kept if any dereference **reads** one of its cells, or if the pointer is **stored into memory** (from where it could be loaded again and dereferenced through a base the pass cannot recognize). Passing it to a call or assigning it to a variable is not enough on its own: the address is followed through assignments to a fixpoint, and any variable used as a dereference base keeps everything it can hold. It runs after inlining, where a read through a callee's parameter has become a read through the literal.

On `Juliet_Test/CWE476_NULL_Pointer_Dereference__int64_t_31_good`:

| | locations | memory writes | KIND |
| --- | --- | --- | --- |
| `1051185d92` (before `4724647fe7`) | 13 | 1 | Safe 2s |
| `4724647fe7` | 147 | 65 | timeout >150s |
| this branch | 19 | 1 | Safe 19s |

803 of the 1098 `correct -> timeout` tasks in #564 are `Juliet_Test`.

## 2. strcpy did not copy the terminating null byte

The loop copies while `src[i] != 0` and exits on `src[i] == 0`, but never wrote that zero to the destination, so the destination was left unterminated:

```c
char dst[4];
strcpy(dst, "AB");
if (dst[0] != 'A' || dst[1] != 'B') reach_error();  // Safe: the characters copy
if (dst[2] != 0) reach_error();                     // Unsafe: the terminator is missing
```

The terminator is now written on the exit edge. It writes `sourceDeref`, which the assume has just constrained to zero, so it needs no literal of its own and composes with the typing change in #566.

Note for #566: that PR turns 177 tasks from `Frontend failed!` into real runs. Until this is in, some of those runs report a wrong verdict rather than an error.

## Guards

- `string_literal_read.c` -- a literal whose characters are read keeps its initialization. Fails (UNSAFE) against an earlier version of this pass that only looked at the dereference root.
- `strcpy_terminator.c` -- fails (UNSAFE) without the terminator write.

77/77 fixtures, 268/268 canaries, `theta-xcfa` and `theta-core` unit tests, spotless clean.

