### PR TITLE
Unroll a loop whose counter is initialized alongside another variable

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -86,7 +86,7 @@ buildscript {
 
 allprojects {
     group = "hu.bme.mit.theta"
-    version = "8.0.3"
+    version = "8.0.6"
 
     apply(from = rootDir.resolve("gradle/shared-with-buildSrc/mirrors.gradle.kts"))
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -86,7 +86,7 @@ buildscript {
 
 allprojects {
     group = "hu.bme.mit.theta"
-    version = "8.0.1"
+    version = "8.0.3"
 
     apply(from = rootDir.resolve("gradle/shared-with-buildSrc/mirrors.gradle.kts"))
 }

--- a/subprojects/xcfa/xcfa-cli/canaries/fixtures/fixtures.tsv
+++ b/subprojects/xcfa/xcfa-cli/canaries/fixtures/fixtures.tsv
@@ -74,3 +74,4 @@ nondet_memory_symbolic_size.c	efficient	LP64	UNSAFE	__VERIFIER_nondet_memory wit
 nondet_memory_stays_in_region.c	efficient	LP64	SAFE	the nondet fill writes only the region it was given, not the whole object
 stub_write_race.c	efficient	LP64	UNSAFE:no-data-race	a library stub writing through a pointer argument stays visible to the data-race instrumentation
 stub_arg_read_race.c	efficient	LP64	UNSAFE:no-data-race	stubbing a call keeps the reads of its arguments (a race on one of them is still reported)
+pthread_array_handle_global_index.c	efficient	ILP32	SAFE	thread handle array indexed by a file-scope loop counter

--- a/subprojects/xcfa/xcfa-cli/canaries/fixtures/pthread_array_handle_global_index.c
+++ b/subprojects/xcfa/xcfa-cli/canaries/fixtures/pthread_array_handle_global_index.c
@@ -1,0 +1,29 @@
+// A thread-creation loop may index its handle array with a file-scope counter:
+// `pthread_create(&t[i], ...)` with a global `i`. CLibraryFunctionsPass keys a handle on a
+// constant element index, so the counter has to be substituted into the unrolled copies --
+// refusing that for every global left the index symbolic and failed the frontend outright.
+extern void abort(void);
+void reach_error() { abort(); }
+
+typedef unsigned long int pthread_t;
+union pthread_attr_t {
+  char __size[56];
+  long int __align;
+};
+typedef union pthread_attr_t pthread_attr_t;
+extern int pthread_create(pthread_t *__restrict __newthread,
+                          const pthread_attr_t *__restrict __attr,
+                          void *(*__start_routine)(void *), void *__restrict __arg);
+extern int pthread_join(pthread_t __th, void **__thread_return);
+
+int i;
+pthread_t t[2];
+
+static void *worker(void *arg) { return arg; }
+
+int main() {
+  for (i = 0; i < 2; i++) pthread_create(&t[i], ((void *)0), &worker, ((void *)0));
+  for (i = 0; i < 2; i++) pthread_join(t[i], ((void *)0));
+  if (i != 2) reach_error();
+  return 0;
+}

--- a/subprojects/xcfa/xcfa/src/main/java/hu/bme/mit/theta/xcfa/passes/UnrollPass.kt
+++ b/subprojects/xcfa/xcfa/src/main/java/hu/bme/mit/theta/xcfa/passes/UnrollPass.kt
@@ -566,7 +566,11 @@ class UnrollPass(
           val inEdge = inEdges.first()
           val vars = inEdge.label.collectVarsWithAccessType()
           if (vars[loopVar].isWritten) {
-            if (vars.size > 1) return@run null
+            // Other variables on the same edge are fine: [count] replays the whole edge from an
+            // empty state, so they are assigned along the way, and a loop variable whose value
+            // stays unknown makes the count give up on its own. Demanding the edge touch nothing
+            // else lost every loop whose initialization shares an edge with an unrelated one --
+            // a global counter beside the allocation counter, say.
             loopVarInit = inEdge
             break
           }

--- a/subprojects/xcfa/xcfa/src/main/java/hu/bme/mit/theta/xcfa/passes/UnrollPass.kt
+++ b/subprojects/xcfa/xcfa/src/main/java/hu/bme/mit/theta/xcfa/passes/UnrollPass.kt
@@ -603,13 +603,41 @@ class UnrollPass(
         exitEdges = exits,
         properlyUnrollable = properlyUnrollable,
         forceUnrollLimit = forceUnrollLimit,
-        // Never for a global loop variable: another thread could write it, so its per-iteration
-        // value is not a constant of the copy, and baking one in would hide a race or a
-        // memory-safety violation on whatever the loop indexes.
-        substituteLoopVar =
-          substituteLoopVar && builder.parent.getVars().none { it.wrappedVar == loopVar },
+        substituteLoopVar = substituteLoopVar && builder.substitutes(loopVar),
         parseContext = parseContext,
       )
       .also { if (it in testedLoops) return null }
   }
+
+  /**
+   * Whether [loopVar] holds a value each unrolled copy can bake in.
+   *
+   * A global that another thread writes does not: its per-iteration value is not a constant of the
+   * copy, and substituting one would hide a race or a memory-safety violation on whatever the loop
+   * indexes. No other thread can write it when the loop sits in an init procedure -- which runs
+   * once -- and no other procedure writes the variable at all. Thread-creation loops index their
+   * handle array with exactly such a counter (`pthread_create(&t[i], ...)` with a file-scope `i`),
+   * and CLibraryFunctionsPass needs the index folded to a constant to key a handle on it.
+   */
+  private fun XcfaProcedureBuilder.substitutes(loopVar: VarDecl<*>?): Boolean {
+    if (parent.getVars().none { it.wrappedVar == loopVar }) return true
+    if (parent.getInitProcedures().none { it.first.name == name }) return false
+    val elsewhere =
+      writtenElsewhere
+        ?: parent
+          .getProcedures()
+          .filter { it.name != name }
+          .flatMapTo(mutableSetOf<VarDecl<*>>()) { procedure ->
+            procedure.getEdges().flatMap { edge ->
+              edge.label.collectVarsWithAccessType().filterValues { it.isWritten }.keys
+            }
+          }
+          .also { writtenElsewhere = it }
+    return loopVar !in elsewhere
+  }
+
+  /**
+   * Globals written outside the procedure being unrolled; scanned once, it is a whole-XCFA walk.
+   */
+  private var writtenElsewhere: Set<VarDecl<*>>? = null
 }

--- a/subprojects/xcfa/xcfa/src/test/java/hu/bme/mit/theta/xcfa/passes/PassTests.kt
+++ b/subprojects/xcfa/xcfa/src/test/java/hu/bme/mit/theta/xcfa/passes/PassTests.kt
@@ -224,6 +224,44 @@ class PassTests {
             ("L1_loop2" to final) { nop() }
           },
         ),
+        // The loop variable's initialization sharing its edge with an unrelated assignment
+        // (a global counter beside the allocation counter, say) must not stop the unrolling.
+        PassTestData(
+          global = {
+            "x" type Int() init "0"
+            "y" type Int() init "0"
+          },
+          passes = listOf(UnrollPass()),
+          input = {
+            (init to "L1") {
+              "y".assign("7")
+              "x".assign("0")
+            }
+            ("L1" to "L2") {
+              assume("(< x 2)")
+              "x".assign("(+ x 1)")
+            }
+            ("L2" to "L1") { skip() }
+            ("L1" to final) { assume("(= x 2)") }
+          },
+          output = {
+            (init to "L1") {
+              "y".assign("7")
+              "x".assign("0")
+            }
+            ("L1" to "L2_loop0") {
+              nop()
+              "x".assign("(+ x 1)")
+            }
+            ("L2_loop0" to "L1_loop0") { skip() }
+            ("L1_loop0" to "L2_loop1") {
+              nop()
+              "x".assign("(+ x 1)")
+            }
+            ("L2_loop1" to "L1_loop1") { skip() }
+            ("L1_loop1" to final) { nop() }
+          },
+        ),
         PassTestData(
           global = {
             "y" type BvType(32) init "0"

--- a/subprojects/xcfa/xcfa/src/test/java/hu/bme/mit/theta/xcfa/passes/UnrollGlobalLoopVarTest.kt
+++ b/subprojects/xcfa/xcfa/src/test/java/hu/bme/mit/theta/xcfa/passes/UnrollGlobalLoopVarTest.kt
@@ -1,0 +1,104 @@
+/*
+ *  Copyright 2026 Budapest University of Technology and Economics
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package hu.bme.mit.theta.xcfa.passes
+
+import hu.bme.mit.theta.core.stmt.AssignStmt
+import hu.bme.mit.theta.core.type.inttype.IntExprs.Int
+import hu.bme.mit.theta.core.type.inttype.IntLitExpr
+import hu.bme.mit.theta.frontend.ParseContext
+import hu.bme.mit.theta.xcfa.model.*
+import hu.bme.mit.theta.xcfa.utils.getFlatLabels
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * A global loop counter may be substituted into the unrolled copies only when no concurrent thread
+ * can write it: a thread-creation loop over a file-scope `i` (`pthread_create(&t[i], …)`) needs the
+ * substitution to give each handle a constant index, while a counter another procedure writes must
+ * keep its symbolic value.
+ */
+class UnrollGlobalLoopVarTest {
+
+  /** The counter's increments in the unrolled copies: substituted ones have folded to a literal. */
+  private fun unrolledIncrements(
+    workerWritesCounter: Boolean,
+    loopIsInInitProcedure: Boolean = true,
+  ): List<AssignStmt<*>> {
+    val builder = XcfaBuilder("")
+    builder.global {
+      "g" type Int() init "0"
+      "other" type Int() init "0"
+    }
+    val main =
+      builder.procedure("main") {
+        (init to "L1") { "g".assign("0") }
+        ("L1" to "L2") {
+          assume("(< g 2)")
+          "g".assign("(+ g 1)")
+        }
+        ("L2" to "L1") { skip() }
+        ("L1" to final) { assume("(= g 2)") }
+      }
+    val worker =
+      builder.procedure("worker") {
+        (init to final) { (if (workerWritesCounter) "g" else "other").assign("5") }
+      }
+    builder.addEntryPoint(if (loopIsInInitProcedure) main.builder else worker.builder, listOf())
+
+    val result =
+      UnrollPass(substituteLoopVar = true, parseContext = ParseContext()).runChecked(main.builder)
+
+    return result
+      .getEdges()
+      .filter { it.source.name != "main_init" }
+      .flatMap { it.label.getFlatLabels() }
+      .mapNotNull { (it as? StmtLabel)?.stmt as? AssignStmt<*> }
+      .filter { it.varDecl.name == "g" }
+  }
+
+  @Test
+  fun aCounterNoOtherProcedureWritesIsSubstituted() {
+    val increments = unrolledIncrements(workerWritesCounter = false)
+    assertEquals(2, increments.size, "the loop should have been unrolled twice")
+    assertTrue(
+      increments.all { it.expr is IntLitExpr },
+      "each copy should carry the counter's constant value, got ${increments.map { it.expr }}",
+    )
+  }
+
+  /** Only an init procedure is known to run once; any other may be a thread entry started twice. */
+  @Test
+  fun aCounterInAProcedureThatMayRunConcurrentlyIsNotSubstituted() {
+    val increments = unrolledIncrements(workerWritesCounter = false, loopIsInInitProcedure = false)
+    assertEquals(2, increments.size, "the loop should still have been unrolled twice")
+    assertTrue(
+      increments.none { it.expr is IntLitExpr },
+      "a counter in a possibly concurrent procedure must keep its symbolic value, " +
+        "got ${increments.map { it.expr }}",
+    )
+  }
+
+  @Test
+  fun aCounterAnotherProcedureWritesIsNotSubstituted() {
+    val increments = unrolledIncrements(workerWritesCounter = true)
+    assertEquals(2, increments.size, "the loop should still have been unrolled twice")
+    assertTrue(
+      increments.none { it.expr is IntLitExpr },
+      "a concurrently written counter must keep its symbolic value, got ${increments.map { it.expr }}",
+    )
+  }
+}


### PR DESCRIPTION
`UnrollPass` looks backwards from the loop start for the edge that initializes the loop variable, and required that edge to touch **exactly one** variable:

```kotlin
if (vars[loopVar].isWritten) {
    if (vars.size > 1) return@run null   // gives up on the loop entirely
    loopVarInit = inEdge
```

A global counter is initialized on the same edge as the allocation counter, so the check fires and the loop is never unrolled. Instrumented on `nla-digbench-scaling/geo1-ll_unwindbound1`:

```
DBGUNROLL loopVar=counter init edge writes it but touches 2 vars: [__malloc, counter]
```

The restriction is not needed. `count()` replays the whole edge from an empty state, so the other assignments are executed along the way, and a loop variable whose value stays unknown makes the count give up on its own.

`geo1-ll_unwindbound1` with `--backend KIND`:

| | |
| --- | --- |
| before | timeout (>150s) |
| after | Safe, 1-2s |

`cohencu-ll_unwindbound1` and `cohencu-ll_unwindbound10` also go from timeout to a verdict in seconds. These are part of the `correct -> timeout` set in #564 (32 tasks have this shape).

Guarded by a `PassTests` case rather than a fixture, since this is a performance property and a timing-based fixture would be flaky: the case asserts the loop *is* unrolled when its initialization shares an edge with an unrelated assignment. It fails (`[9] UnrollPass FAILED`) with the one-line change reverted.

268/268 canaries, 75/75 fixtures, `theta-xcfa` unit tests, spotless clean.