### PR TITLE
Do not wrap a simplified call argument when carrying its C type over

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -86,7 +86,7 @@ buildscript {
 
 allprojects {
     group = "hu.bme.mit.theta"
-    version = "8.0.1"
+    version = "8.0.4"
 
     apply(from = rootDir.resolve("gradle/shared-with-buildSrc/mirrors.gradle.kts"))
 }

--- a/subprojects/xcfa/xcfa/src/main/java/hu/bme/mit/theta/xcfa/utils/Utils.kt
+++ b/subprojects/xcfa/xcfa/src/main/java/hu/bme/mit/theta/xcfa/utils/Utils.kt
@@ -174,7 +174,7 @@ fun XcfaLabel.simplify(valuation: MutableValuation, parseContext: ParseContext):
     is StartLabel ->
       StartLabel(
         name,
-        params.map { ExprUtils.simplify(it, valuation).withMetadata(parseContext, it) },
+        params.map { ExprUtils.simplify(it, valuation).withCTypeOf(parseContext, it) },
         pidVar,
         metadata,
         tempLookup,
@@ -189,7 +189,7 @@ fun XcfaLabel.simplify(valuation: MutableValuation, parseContext: ParseContext):
         // `cType` is identity-keyed, so a rebuilt argument carries none and a later frontend pass
         // reading it (AtomicFunctionsPass wants the pointee of its pointer argument) sees a bare
         // SMT type instead -- carry it over, as the statement branches above do.
-        params.map { ExprUtils.simplify(it, valuation).withMetadata(parseContext, it) },
+        params.map { ExprUtils.simplify(it, valuation).withCTypeOf(parseContext, it) },
         metadata,
         tempLookup,
         isLibraryFunction,
@@ -199,6 +199,24 @@ fun XcfaLabel.simplify(valuation: MutableValuation, parseContext: ParseContext):
 
     else -> this
   }
+
+/**
+ * [metadataSource]'s C type, recorded on this expression when it has none of its own.
+ *
+ * Unlike [withMetadata] this never wraps: a call argument is matched syntactically by the passes
+ * that lower the call (`MemoryFunctionsPass` looks for the pointer of a `memset`), and a wrapper
+ * makes the argument unrecognizable, so the call is left as an `InvokeLabel` that later stages
+ * refuse outright.
+ */
+private fun <T : Type> Expr<T>.withCTypeOf(
+  parseContext: ParseContext,
+  metadataSource: Expr<*>,
+): Expr<T> {
+  if (!parseContext.metadata.getMetadataValue(metadataSource, "cType").isPresent) return this
+  if (parseContext.metadata.getMetadataValue(this, "cType").isPresent) return this
+  parseContext.metadata.create(this, "cType", CComplexType.getType(metadataSource, parseContext))
+  return this
+}
 
 private fun <T : Type> Expr<T>.withMetadata(
   parseContext: ParseContext,

--- a/subprojects/xcfa/xcfa/src/test/java/hu/bme/mit/theta/xcfa/passes/UtilsTest.kt
+++ b/subprojects/xcfa/xcfa/src/test/java/hu/bme/mit/theta/xcfa/passes/UtilsTest.kt
@@ -18,16 +18,46 @@ package hu.bme.mit.theta.xcfa.passes
 import hu.bme.mit.theta.core.decl.Decl
 import hu.bme.mit.theta.core.decl.Decls.Var
 import hu.bme.mit.theta.core.decl.VarDecl
+import hu.bme.mit.theta.core.model.MutableValuation
 import hu.bme.mit.theta.core.stmt.Stmts.*
+import hu.bme.mit.theta.core.type.inttype.IntExprs.Add
 import hu.bme.mit.theta.core.type.inttype.IntExprs.Eq
 import hu.bme.mit.theta.core.type.inttype.IntExprs.Int
+import hu.bme.mit.theta.frontend.ParseContext
+import hu.bme.mit.theta.frontend.transformation.model.types.complex.compound.CPointer
+import hu.bme.mit.theta.frontend.transformation.model.types.complex.integer.cint.CSignedInt
 import hu.bme.mit.theta.xcfa.model.*
+import hu.bme.mit.theta.xcfa.utils.simplify
 import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 
 class UtilsTest {
+
+  /**
+   * The passes that lower a call match its arguments syntactically, so simplification must hand
+   * back the argument itself rather than a wrapper carrying the same C type. A wrapped pointer made
+   * `memset` unrecognizable, and the `InvokeLabel` left behind was refused by the monolithic
+   * backends.
+   */
+  @Test
+  fun simplifyKeepsCallArgumentsUnwrapped() {
+    val parseContext = ParseContext()
+    val p = Var("p", Int())
+    val signed = CSignedInt(null, parseContext)
+    parseContext.metadata.create(p.ref, "cType", signed)
+    // An argument that folds back to `p`, but whose own recorded type differs from `p`'s: this is
+    // what used to make the carried-over type wrap the result instead of just labelling it.
+    val argument = Add(listOf(p.ref, Int(0)))
+    parseContext.metadata.create(argument, "cType", CPointer(null, signed, parseContext))
+    val label = InvokeLabel("memset", listOf(argument), EmptyMetaData, mapOf())
+
+    val simplified = label.simplify(MutableValuation(), parseContext) as InvokeLabel
+
+    Assertions.assertEquals(p.ref, simplified.params[0])
+  }
 
   companion object {
 

--- a/subprojects/xcfa/xcfa/src/test/java/hu/bme/mit/theta/xcfa/passes/UtilsTest.kt
+++ b/subprojects/xcfa/xcfa/src/test/java/hu/bme/mit/theta/xcfa/passes/UtilsTest.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2025 Budapest University of Technology and Economics
+ *  Copyright 2026 Budapest University of Technology and Economics
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -57,6 +57,43 @@ class UtilsTest {
     val simplified = label.simplify(MutableValuation(), parseContext) as InvokeLabel
 
     Assertions.assertEquals(p.ref, simplified.params[0])
+  }
+
+  /** A folded argument takes the C type the original argument carried. */
+  @Test
+  fun simplifyCarriesTheCTypeOntoAFoldedArgument() {
+    val parseContext = ParseContext()
+    val n = Var("n", Int())
+    val signed = CSignedInt(null, parseContext)
+    val argument = Add(listOf(n.ref, Int(1)))
+    parseContext.metadata.create(argument, "cType", signed)
+    val valuation = MutableValuation()
+    valuation.put(n, Int(5))
+    val label = InvokeLabel("f", listOf(argument), EmptyMetaData, mapOf())
+
+    val simplified = (label.simplify(valuation, parseContext) as InvokeLabel).params[0]
+
+    Assertions.assertEquals(Int(6), simplified)
+    Assertions.assertEquals(
+      signed,
+      parseContext.metadata.getMetadataValue(simplified, "cType").get(),
+    )
+  }
+
+  /** Without a recorded C type on the original there is nothing to carry over. */
+  @Test
+  fun simplifyLeavesAnUntypedArgumentUntyped() {
+    val parseContext = ParseContext()
+    val n = Var("n", Int())
+    val argument = Add(listOf(n.ref, Int(1)))
+    val valuation = MutableValuation()
+    valuation.put(n, Int(5))
+    val label = StartLabel("t", listOf(argument), Var("pid", Int()), EmptyMetaData)
+
+    val simplified = (label.simplify(valuation, parseContext) as StartLabel).params[0]
+
+    Assertions.assertEquals(Int(6), simplified)
+    Assertions.assertFalse(parseContext.metadata.getMetadataValue(simplified, "cType").isPresent)
   }
 
   companion object {


### PR DESCRIPTION
`XcfaLabel.simplify` carries a call argument's C type over to the rebuilt expression through `withMetadata`, which **wraps** the expression in `Pos` when the rebuilt one already carries a different type. The passes that lower a call match its arguments syntactically, so a wrapped pointer is no longer recognizable:

```
InvokeLabel -> memset(call_memset_ret11, (bvpos main::cstats*), #b0..0, #b0..101000)
```

`MemoryFunctionsPass` gives up on that call, the `InvokeLabel` survives, and the monolithic backends refuse it outright:

```
Process failed! (XcfaSingleThreadToMonolithicAdapter.getMonolithicExpr:81,
                 java.lang.IllegalArgumentException)
```

`ldv-memsafety/memset2` with `--portfolio TERMINATION` crashes in ~3s on master; it was solved in ~3s before. In a portfolio run it shows up as a timeout, because the remaining configs burn the budget after this one dies.

Wrapping was never needed here: the case this carrying was added for is a rebuilt argument with *no* type of its own, which only needs the type recorded. `withCTypeOf` does that and returns the expression untouched.

Bisected to 33f30ce952 (mine), and confirmed by reverting only that half.

## Guard

`UtilsTest.simplifyKeepsCallArgumentsUnwrapped` builds the condition that triggers the wrap -- an argument that folds back to `p`, whose own recorded type differs from `p`'s -- and asserts the result is `p` rather than a wrapper. It fails without the change.

268/268 canaries, 75/75 fixtures, `theta-xcfa` and `theta-core` unit tests, spotless clean.